### PR TITLE
Add brief missing subcommand and expand knowledge base

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # brief
 
-A single-binary CLI tool that detects a software project's toolchain, configuration, and conventions, then outputs a structured report. Written in Go, 54 ecosystems, 295 tool definitions.
+A single-binary CLI tool that detects a software project's toolchain, configuration, and conventions, then outputs a structured report. Written in Go, 54 ecosystems, 355 tool definitions.
 
 brief answers the bootstrap questions every AI coding agent, new contributor, and CI pipeline faces: what language is this, how do I install dependencies, how do I run the tests, what linter is configured.
 
@@ -41,6 +41,7 @@ Or download a binary from [releases](https://github.com/git-pkgs/brief/releases)
 ```
 brief [flags] [path | url]        Detect project toolchain
 brief diff [flags] [ref1] [ref2]  Detect only what changed between refs
+brief missing [flags] [path]      Show recommended tooling gaps
 brief enrich [flags] [path]       Detect and enrich with external data
 brief list tools                  All tools in the knowledge base
 brief list ecosystems             Supported ecosystems
@@ -64,34 +65,38 @@ Remote sources are shallow-cloned by default. Use `--depth 0` for a full clone, 
 JSON when piped, human-readable on a TTY. Force either with `--json` or `--human`. Use `--category test` to filter to a single category.
 
 ```
-brief dev — /home/user/forge
+brief dev — /home/user/myproject
 
 Language:        Go
 Package Manager: Go Modules (go mod download)
                  Lockfile: go.sum
-                 7 runtime (222 total)
+                 9 runtime (223 total)
 
 Test:        go test (go test ./...)
 Lint:        golangci-lint (golangci-lint run)  [.golangci.yml]
 Format:      gofmt (gofmt -w .)
-Build:       GoReleaser (goreleaser release --clean)  [.goreleaser.yml]
+Docs:        pkgsite (go run golang.org/x/pkgsite/cmd/pkgsite@latest)
+Build:       GoReleaser (goreleaser release --clean)  [.goreleaser.yaml]
+Security:    govulncheck (govulncheck ./...)
 CI:          GitHub Actions  [.github/workflows/]
+Coverage:    go test -cover (go test -coverprofile=coverage.out ./...)
 Dep Updates: Dependabot  [.github/dependabot.yml]
 
 Style:       tabs (inferred)  LF
-Layout:      internal/ cmd/
+Layout:      cmd/
 
              OS: ubuntu-latest, macos-latest, windows-latest (CI matrix)
 
 Resources:   README.md
+Resources:   CONTRIBUTING.md
 Resources:   LICENSE (MIT)
 
-Git:         branch main  58 commits
-             origin: git@github.com:git-pkgs/forge.git
+Git:         branch main  71 commits
+             origin: git@github.com:user/myproject.git
 
-Lines:       22912 code  191 files (scc)
+Lines:       9295 code  397 files (scc)
 
-112.0ms  311 files checked  8/230 tools matched
+148.7ms  428 files checked  11/355 tools matched
 ```
 
 Use `--verbose` to include homepage, docs, and repo links for each detected tool.
@@ -110,6 +115,37 @@ With no arguments it auto-detects the default branch from `origin/HEAD`, falling
 
 Same output format as `brief` -- JSON when piped, human-readable on a TTY.
 
+## Missing
+
+`brief missing` checks which recommended tool categories are absent for the project's detected ecosystems. It compares what's detected against five categories every project benefits from: test, lint, format, typecheck, and docs.
+
+```
+brief missing .
+brief missing --json .
+```
+
+For each gap it suggests the canonical tool for that ecosystem, with the command to run and a link to docs.
+
+```
+Detected: python
+
+Missing recommended tooling:
+
+  Test         No test tool configured
+               Suggested: pytest (pytest)
+               https://docs.pytest.org
+
+  Lint         No lint tool configured
+               Suggested: Ruff (ruff check .)
+               https://docs.astral.sh/ruff/
+
+  Format       No format tool configured
+               Suggested: Black (black .)
+               https://black.readthedocs.io/en/stable/
+```
+
+Tools built into the language runtime (go test, gofmt, cargo clippy, dart analyze, deno lint, etc.) are detected automatically when the language is present and won't show as missing.
+
 ## Enrichment
 
 `brief enrich` runs the same scan, then fetches metadata from external APIs about the project itself: what packages it publishes, their download counts and dependents, runtime end-of-life status, and OpenSSF Scorecard.
@@ -124,15 +160,15 @@ Data sources: [ecosyste.ms](https://ecosyste.ms) for published package metadata,
 
 ## What it detects
 
-54 language ecosystems with 295 tool definitions across 20 categories.
+54 language ecosystems with 355 tool definitions across 20 categories.
 
 **Languages (54):** Go, Ruby, Python, JavaScript, TypeScript, Rust, Java, Kotlin, Scala, Elixir, PHP, Swift, C#, Dart, Haskell, Clojure, Crystal, Julia, Nim, Zig, Lua, Perl, R, D, Elm, Gleam, Haxe, Nix, Deno, C, C++, Objective-C, Erlang, OCaml, F#, Groovy, Solidity, GDScript, Fortran, COBOL, Ada, VHDL, Verilog, Mojo, Roc, V, Odin, Scheme, Racket, Prolog, Tcl, Common Lisp, Emacs Lisp, plus CocoaPods and Conda ecosystems.
 
-**Test (33):** go test, Jest, Vitest, Mocha, AVA, RSpec, Minitest, pytest, JUnit, PHPUnit, ExUnit, EUnit, cargo test, Google Test, Catch2, Playwright, Cypress, MSW, Cucumber, Selenium, k6, Locust, Artillery, criterion, axe-core, Lighthouse CI, and more.
+**Test (46):** go test, Jest, Vitest, Mocha, AVA, RSpec, Minitest, pytest, JUnit, PHPUnit, ExUnit, EUnit, cargo test, Google Test, Catch2, Playwright, Cypress, MSW, Locust, Artillery, axe-core, Lighthouse CI, XCTest, dart test, deno test, kotlin.test, ScalaTest, crystal spec, Hspec, Alcotest, zig test, gleam test, and more.
 
-**Lint (20):** golangci-lint, ESLint, RuboCop, Ruff, Clippy, clang-tidy, Biome, Stylelint, commitlint, hadolint, ShellCheck, markdownlint, Semgrep, pre-commit, Lefthook, Husky, and more.
+**Lint (31):** golangci-lint, ESLint, RuboCop, Ruff, Clippy, clang-tidy, Biome, Stylelint, commitlint, hadolint, ShellCheck, markdownlint, Semgrep, pre-commit, Lefthook, Husky, detekt, PHP_CodeSniffer, SwiftLint, Credo, HLint, elvis, clj-kondo, dart analyze, deno lint, WartRemover, Ameba, and more.
 
-**Format (13):** gofmt, Prettier, Black, rustfmt, isort, clang-format, ocamlformat, dprint, scalafmt, ktlint, SwiftFormat, StandardRB, PHP CS Fixer.
+**Format (25):** gofmt, Prettier, Black, rustfmt, isort, clang-format, ocamlformat, dprint, scalafmt, ktlint, SwiftFormat, StandardRB, PHP CS Fixer, mix format, erlfmt, Ormolu, dart format, deno fmt, dotnet format, zig fmt, crystal tool format, cljfmt, nimpretty, gleam format, google-java-format.
 
 **Build (48):** Webpack, Vite, esbuild, Rollup, Parcel, tsup, Rspack, GoReleaser, Mage, Rake, CMake, Make, Meson, Autotools, Hardhat, Foundry, Tailwind CSS, PostCSS, Sass, Less, UnoCSS, plus framework detection for Rails, Django, FastAPI, Express, Fastify, Koa, Hono, NestJS, AdonisJS, Gin, Phoenix, Spring Boot, Actix, Next.js, Nuxt, Remix, Angular, Ember.js, SolidJS, Qwik, Astro, Gatsby, SvelteKit, Eleventy.
 
@@ -152,7 +188,13 @@ Data sources: [ecosyste.ms](https://ecosyste.ms) for published package metadata,
 
 **i18n (5):** i18next, gettext, Rails i18n, Crowdin, Transifex.
 
-**Also:** package managers (39), type checkers (5), docs generators (9), security tools (3), coverage services (3), dependency update bots (3), environment tools (9).
+**Docs (18):** pkgsite, Sphinx, MkDocs, Javadoc, Docusaurus, VitePress, Storybook, Jekyll, Doxygen, ExDoc, Dokka, phpDocumentor, cargo doc, dart doc, deno doc, Docsify, Starlight, and more.
+
+**Security (9):** govulncheck, npm audit, pip-audit, bundler-audit, cargo-audit, OWASP Dependency-Check, Snyk, Socket, and more.
+
+**Coverage (9):** go test -cover, coverage.py, SimpleCov, JaCoCo, c8, cargo-tarpaulin, Codecov, Coveralls, and more.
+
+**Also:** package managers (39), type checkers (6), dependency update bots (3), environment tools (9).
 
 Run `brief list tools` for the full list.
 
@@ -164,6 +206,7 @@ Detection rules are data, not code. Each tool is defined in a TOML file under `k
 [tool]
 name = "RSpec"
 category = "test"
+default = true
 homepage = "https://rspec.info"
 description = "BDD testing framework for Ruby"
 
@@ -178,6 +221,8 @@ alternatives = ["rake spec", "rspec"]
 [config]
 files = [".rspec", "spec/spec_helper.rb"]
 ```
+
+The `default = true` flag marks a tool as the canonical choice for its category in that ecosystem. The `brief missing` command uses this to suggest the right tool when a category is absent.
 
 Detection uses five primitives: file/directory presence, dependency names from parsed manifests, file content matching, structured key existence (JSON/TOML), and ecosystem filtering to prevent cross-language false positives.
 

--- a/brief.go
+++ b/brief.go
@@ -156,6 +156,26 @@ type RuntimeEOL struct {
 	Latest    string `json:"latest,omitempty"` // latest patch version
 }
 
+// MissingReport is the output of a brief missing analysis.
+type MissingReport struct {
+	Version    string            `json:"version"`
+	Path       string            `json:"path"`
+	Ecosystems []string          `json:"ecosystems"`
+	Missing    []MissingCategory `json:"missing"`
+}
+
+// MissingCategory describes a tool category that has no detected tools
+// despite the ecosystem having known tools for it.
+type MissingCategory struct {
+	Category     string `json:"category"`
+	Label        string `json:"label"`
+	Ecosystem    string `json:"ecosystem"`
+	Suggested    string `json:"suggested"`
+	SuggestedCmd string `json:"suggested_cmd,omitempty"`
+	Description  string `json:"description,omitempty"`
+	Docs         string `json:"docs,omitempty"`
+}
+
 // Report is the complete output of a brief analysis.
 type Report struct {
 	Version         string                 `json:"version"`

--- a/cmd/brief/main.go
+++ b/cmd/brief/main.go
@@ -36,6 +36,9 @@ func main() {
 		case "diff":
 			cmdDiff(os.Args[2:])
 			return
+		case "missing":
+			cmdMissing(os.Args[2:])
+			return
 		}
 	}
 

--- a/cmd/brief/missing.go
+++ b/cmd/brief/missing.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/git-pkgs/brief"
+	"github.com/git-pkgs/brief/detect"
+	"github.com/git-pkgs/brief/kb"
+	"github.com/git-pkgs/brief/report"
+)
+
+func cmdMissing(args []string) {
+	fs := flag.NewFlagSet("brief missing", flag.ExitOnError)
+	jsonFlag := fs.Bool("json", false, "Force JSON output")
+	humanFlag := fs.Bool("human", false, "Force human-readable output")
+	scanDepth := fs.Int("scan-depth", 0, "Max directory depth for language detection (default 4)")
+	skip := fs.String("skip", "", "Additional directories to skip, comma-separated")
+	_ = fs.Parse(args)
+
+	path := "."
+	if fs.NArg() > 0 {
+		path = fs.Arg(0)
+	}
+
+	knowledgeBase, err := kb.Load(brief.KnowledgeFS)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "error loading knowledge base: %v\n", err)
+		os.Exit(1)
+	}
+
+	engine := detect.New(knowledgeBase, path)
+	engine.ScanDepth = *scanDepth
+	if *skip != "" {
+		engine.SkipDirs = strings.Split(*skip, ",")
+	}
+	r, err := engine.Run()
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	mr := engine.Missing(r)
+
+	useJSON := *jsonFlag || (!*humanFlag && !isTTY())
+
+	if useJSON {
+		if err := report.MissingJSON(os.Stdout, mr); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "error writing JSON: %v\n", err)
+			os.Exit(1)
+		}
+	} else {
+		report.MissingHuman(os.Stdout, mr)
+	}
+}

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -1256,6 +1256,85 @@ func detectLicenseType(path string) string {
 	return normalized
 }
 
+// recommendedCategories are tool categories that every project benefits from.
+var recommendedCategories = map[string]string{
+	"test":      "Test",
+	"lint":      "Lint",
+	"format":    "Format",
+	"typecheck": "Typecheck",
+	"docs":      "Docs",
+}
+
+// Missing computes which recommended tool categories have no detected tools
+// for the project's ecosystems. It requires Run() to have been called first
+// so that detectedEcosystems is populated.
+func (e *Engine) Missing(r *brief.Report) *brief.MissingReport {
+	mr := &brief.MissingReport{
+		Version: brief.Version,
+		Path:    r.Path,
+	}
+
+	for eco := range e.detectedEcosystems {
+		mr.Ecosystems = append(mr.Ecosystems, eco)
+	}
+	sort.Strings(mr.Ecosystems)
+
+	// Build set of categories that were actually detected.
+	detected := make(map[string]bool)
+	for cat := range r.Tools {
+		detected[cat] = true
+	}
+
+	// Check each recommended category against each detected ecosystem.
+	categoryOrder := []string{"test", "lint", "format", "typecheck", "docs"}
+	for _, cat := range categoryOrder {
+		if detected[cat] {
+			continue
+		}
+
+		label := recommendedCategories[cat]
+
+		// Find the best tool for this category across detected ecosystems.
+		// Prefer tools marked as default, fall back to first match.
+		var best *kb.ToolDef
+		var bestEco string
+		for _, eco := range mr.Ecosystems {
+			for _, tool := range e.KB.ToolsForEcosystem(eco) {
+				if tool.Tool.Category != cat {
+					continue
+				}
+				if best == nil {
+					best = tool
+					bestEco = eco
+				}
+				if tool.Tool.Default {
+					best = tool
+					bestEco = eco
+					goto found
+				}
+			}
+		}
+		if best == nil {
+			continue
+		}
+	found:
+		mc := brief.MissingCategory{
+			Category:    cat,
+			Label:       label,
+			Ecosystem:   bestEco,
+			Suggested:   best.Tool.Name,
+			Description: best.Tool.Description,
+			Docs:        best.Tool.Docs,
+		}
+		if best.Commands.Run != "" {
+			mc.SuggestedCmd = best.Commands.Run
+		}
+		mr.Missing = append(mr.Missing, mc)
+	}
+
+	return mr
+}
+
 func rank(c brief.Confidence) int {
 	switch c {
 	case brief.ConfidenceHigh:

--- a/detect/missing_test.go
+++ b/detect/missing_test.go
@@ -1,0 +1,148 @@
+package detect
+
+import (
+	"testing"
+)
+
+func TestMissingPythonProject(t *testing.T) {
+	engine := New(loadKB(t), "../testdata/python-project")
+	r, err := engine.Run()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mr := engine.Missing(r)
+
+	if len(mr.Ecosystems) == 0 {
+		t.Fatal("expected at least one ecosystem")
+	}
+
+	foundPython := false
+	for _, eco := range mr.Ecosystems {
+		if eco == "python" {
+			foundPython = true
+		}
+	}
+	if !foundPython {
+		t.Error("expected python ecosystem")
+	}
+
+	// Python project has pytest, ruff, mypy detected.
+	// Should be missing: format, docs.
+	// Should NOT be missing: test, lint, typecheck.
+	missingCats := make(map[string]bool)
+	for _, m := range mr.Missing {
+		missingCats[m.Category] = true
+	}
+
+	if missingCats["test"] {
+		t.Error("test should not be missing (pytest detected)")
+	}
+	if missingCats["lint"] {
+		t.Error("lint should not be missing (ruff detected)")
+	}
+	if missingCats["typecheck"] {
+		t.Error("typecheck should not be missing (mypy detected)")
+	}
+	if !missingCats["docs"] {
+		t.Error("docs should be missing")
+	}
+}
+
+func TestMissingNodeProject(t *testing.T) {
+	engine := New(loadKB(t), "../testdata/node-project")
+	r, err := engine.Run()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mr := engine.Missing(r)
+
+	missingCats := make(map[string]bool)
+	for _, m := range mr.Missing {
+		missingCats[m.Category] = true
+	}
+
+	// Node project has Jest and ESLint detected.
+	if missingCats["test"] {
+		t.Error("test should not be missing (jest detected)")
+	}
+	if missingCats["lint"] {
+		t.Error("lint should not be missing (eslint detected)")
+	}
+	if !missingCats["format"] {
+		t.Error("format should be missing")
+	}
+	if !missingCats["docs"] {
+		t.Error("docs should be missing")
+	}
+}
+
+func TestMissingEmptyProject(t *testing.T) {
+	engine := New(loadKB(t), "../testdata/empty-project")
+	r, err := engine.Run()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mr := engine.Missing(r)
+
+	// No ecosystems detected, so nothing should be missing.
+	if len(mr.Missing) != 0 {
+		t.Errorf("expected no missing categories for empty project, got %d", len(mr.Missing))
+	}
+}
+
+func TestMissingSuggestsDefaultTool(t *testing.T) {
+	engine := New(loadKB(t), "../testdata/node-project")
+	r, err := engine.Run()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mr := engine.Missing(r)
+
+	for _, m := range mr.Missing {
+		if m.Category == "format" {
+			if m.Suggested != "Prettier" {
+				t.Errorf("expected Prettier as default format suggestion, got %s", m.Suggested)
+			}
+			if m.SuggestedCmd == "" {
+				t.Error("expected suggested command for format")
+			}
+			return
+		}
+	}
+	t.Error("expected format to be in missing categories")
+}
+
+func TestMissingGoProject(t *testing.T) {
+	engine := New(loadKB(t), "../testdata/go-project")
+	r, err := engine.Run()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mr := engine.Missing(r)
+
+	missingCats := make(map[string]bool)
+	for _, m := range mr.Missing {
+		missingCats[m.Category] = true
+	}
+
+	// Go project has go test and golangci-lint detected.
+	if missingCats["test"] {
+		t.Error("test should not be missing")
+	}
+	if missingCats["lint"] {
+		t.Error("lint should not be missing")
+	}
+	// Go has no typecheck tools in KB, so it shouldn't appear.
+	if missingCats["typecheck"] {
+		t.Error("typecheck should not be missing (no Go typecheck tools in KB)")
+	}
+	// Go docs (pkgsite) detects on go.mod, so it's always present.
+	if missingCats["docs"] {
+		t.Error("docs should not be missing (pkgsite is built-in)")
+	}
+}

--- a/kb/kb.go
+++ b/kb/kb.go
@@ -27,6 +27,7 @@ type ToolInfo struct {
 	Docs        string `toml:"docs"`
 	Repo        string `toml:"repo"`
 	Description string `toml:"description"`
+	Default     bool   `toml:"default"` // preferred suggestion for this category in the ecosystem
 }
 
 // DetectInfo holds the detection primitives for a tool.

--- a/knowledge/clojure/clj-kondo.toml
+++ b/knowledge/clojure/clj-kondo.toml
@@ -1,0 +1,18 @@
+[tool]
+name = "clj-kondo"
+category = "lint"
+default = true
+homepage = "https://github.com/clj-kondo/clj-kondo"
+docs = "https://github.com/clj-kondo/clj-kondo#readme"
+repo = "https://github.com/clj-kondo/clj-kondo"
+description = "Linter for Clojure"
+
+[detect]
+files = [".clj-kondo/"]
+ecosystems = ["clojure"]
+
+[commands]
+run = "clj-kondo --lint src"
+
+[config]
+files = [".clj-kondo/config.edn"]

--- a/knowledge/clojure/cljfmt.toml
+++ b/knowledge/clojure/cljfmt.toml
@@ -1,0 +1,18 @@
+[tool]
+name = "cljfmt"
+category = "format"
+default = true
+homepage = "https://github.com/weavejester/cljfmt"
+docs = "https://github.com/weavejester/cljfmt#readme"
+repo = "https://github.com/weavejester/cljfmt"
+description = "Clojure code formatter"
+
+[detect]
+ecosystems = ["clojure"]
+[detect.file_contains]
+"project.clj" = ["cljfmt"]
+"deps.edn" = ["cljfmt"]
+
+[commands]
+run = "lein cljfmt check"
+alternatives = ["lein cljfmt fix"]

--- a/knowledge/clojure/clojure-test.toml
+++ b/knowledge/clojure/clojure-test.toml
@@ -1,0 +1,15 @@
+[tool]
+name = "clojure.test"
+category = "test"
+default = true
+homepage = "https://clojure.github.io/clojure/clojure.test-api.html"
+docs = "https://clojure.org/guides/test"
+description = "Built-in Clojure test framework"
+
+[detect]
+files = ["test/", "project.clj", "deps.edn"]
+ecosystems = ["clojure"]
+
+[commands]
+run = "lein test"
+alternatives = ["clojure -X:test"]

--- a/knowledge/cpp/clang-format.toml
+++ b/knowledge/cpp/clang-format.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "clang-format"
 category = "format"
+default = true
 homepage = "https://clang.llvm.org/docs/ClangFormat.html"
 docs = "https://clang.llvm.org/docs/ClangFormatStyleOptions.html"
 description = "C/C++ code formatter"

--- a/knowledge/cpp/clang-tidy.toml
+++ b/knowledge/cpp/clang-tidy.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "clang-tidy"
 category = "lint"
+default = true
 homepage = "https://clang.llvm.org/extra/clang-tidy/"
 docs = "https://clang.llvm.org/extra/clang-tidy/"
 description = "C/C++ linter and static analysis tool"

--- a/knowledge/cpp/doxygen.toml
+++ b/knowledge/cpp/doxygen.toml
@@ -1,0 +1,18 @@
+[tool]
+name = "Doxygen"
+category = "docs"
+default = true
+homepage = "https://www.doxygen.nl"
+docs = "https://www.doxygen.nl/manual/"
+repo = "https://github.com/doxygen/doxygen"
+description = "Documentation generator for C/C++"
+
+[detect]
+files = ["Doxyfile", "Doxyfile.in", "docs/Doxyfile"]
+ecosystems = ["c", "cpp"]
+
+[commands]
+run = "doxygen"
+
+[config]
+files = ["Doxyfile", "Doxyfile.in"]

--- a/knowledge/cpp/gtest.toml
+++ b/knowledge/cpp/gtest.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "Google Test"
 category = "test"
+default = true
 homepage = "https://google.github.io/googletest/"
 docs = "https://google.github.io/googletest/"
 repo = "https://github.com/google/googletest"

--- a/knowledge/crystal/ameba.toml
+++ b/knowledge/crystal/ameba.toml
@@ -1,0 +1,20 @@
+[tool]
+name = "Ameba"
+category = "lint"
+default = true
+homepage = "https://github.com/crystal-ameba/ameba"
+docs = "https://github.com/crystal-ameba/ameba#readme"
+repo = "https://github.com/crystal-ameba/ameba"
+description = "Static code analysis for Crystal"
+
+[detect]
+files = [".ameba.yml"]
+ecosystems = ["crystal"]
+[detect.file_contains]
+"shard.yml" = ["ameba"]
+
+[commands]
+run = "bin/ameba"
+
+[config]
+files = [".ameba.yml"]

--- a/knowledge/crystal/crystal-format.toml
+++ b/knowledge/crystal/crystal-format.toml
@@ -1,0 +1,15 @@
+[tool]
+name = "crystal tool format"
+category = "format"
+default = true
+homepage = "https://crystal-lang.org/reference/man/crystal/#crystal-tool-format"
+docs = "https://crystal-lang.org/reference/man/crystal/#crystal-tool-format"
+description = "Built-in Crystal code formatter"
+
+[detect]
+files = ["shard.yml"]
+ecosystems = ["crystal"]
+
+[commands]
+run = "crystal tool format"
+alternatives = ["crystal tool format --check"]

--- a/knowledge/crystal/crystal-spec.toml
+++ b/knowledge/crystal/crystal-spec.toml
@@ -1,0 +1,14 @@
+[tool]
+name = "crystal spec"
+category = "test"
+default = true
+homepage = "https://crystal-lang.org/reference/guides/testing.html"
+docs = "https://crystal-lang.org/reference/guides/testing.html"
+description = "Built-in Crystal test runner"
+
+[detect]
+files = ["spec/", "shard.yml"]
+ecosystems = ["crystal"]
+
+[commands]
+run = "crystal spec"

--- a/knowledge/csharp/dotnet-format.toml
+++ b/knowledge/csharp/dotnet-format.toml
@@ -1,0 +1,18 @@
+[tool]
+name = "dotnet format"
+category = "format"
+default = true
+homepage = "https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-format"
+docs = "https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-format"
+description = "Built-in .NET code formatter"
+
+[detect]
+files = ["*.sln", "**/*.csproj"]
+ecosystems = ["csharp"]
+
+[commands]
+run = "dotnet format"
+alternatives = ["dotnet format --verify-no-changes"]
+
+[config]
+files = [".editorconfig"]

--- a/knowledge/csharp/dotnet-test.toml
+++ b/knowledge/csharp/dotnet-test.toml
@@ -1,0 +1,15 @@
+[tool]
+name = "dotnet test"
+category = "test"
+default = true
+homepage = "https://learn.microsoft.com/en-us/dotnet/core/testing/"
+docs = "https://learn.microsoft.com/en-us/dotnet/core/testing/"
+description = "Built-in .NET test runner"
+
+[detect]
+files = ["*.sln", "**/*.csproj"]
+ecosystems = ["csharp"]
+
+[commands]
+run = "dotnet test"
+alternatives = ["dotnet test --verbosity normal"]

--- a/knowledge/csharp/roslyn-analyzers.toml
+++ b/knowledge/csharp/roslyn-analyzers.toml
@@ -1,0 +1,15 @@
+[tool]
+name = "Roslyn Analyzers"
+category = "lint"
+default = true
+homepage = "https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview"
+docs = "https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview"
+repo = "https://github.com/dotnet/roslyn-analyzers"
+description = "Built-in .NET code analyzers"
+
+[detect]
+files = ["*.sln", "**/*.csproj"]
+ecosystems = ["csharp"]
+
+[commands]
+run = "dotnet build /p:TreatWarningsAsErrors=true"

--- a/knowledge/dart/dart-analyze.toml
+++ b/knowledge/dart/dart-analyze.toml
@@ -1,0 +1,18 @@
+[tool]
+name = "dart analyze"
+category = "lint"
+default = true
+homepage = "https://dart.dev/tools/dart-analyze"
+docs = "https://dart.dev/tools/analysis"
+description = "Built-in Dart static analyzer"
+
+[detect]
+files = ["pubspec.yaml"]
+ecosystems = ["dart"]
+
+[commands]
+run = "dart analyze"
+alternatives = ["flutter analyze"]
+
+[config]
+files = ["analysis_options.yaml"]

--- a/knowledge/dart/dart-doc.toml
+++ b/knowledge/dart/dart-doc.toml
@@ -1,0 +1,14 @@
+[tool]
+name = "dart doc"
+category = "docs"
+default = true
+homepage = "https://dart.dev/tools/dart-doc"
+docs = "https://dart.dev/tools/dart-doc"
+description = "Built-in Dart documentation generator"
+
+[detect]
+files = ["pubspec.yaml"]
+ecosystems = ["dart"]
+
+[commands]
+run = "dart doc"

--- a/knowledge/dart/dart-format.toml
+++ b/knowledge/dart/dart-format.toml
@@ -1,0 +1,15 @@
+[tool]
+name = "dart format"
+category = "format"
+default = true
+homepage = "https://dart.dev/tools/dart-format"
+docs = "https://dart.dev/tools/dart-format"
+description = "Built-in Dart code formatter"
+
+[detect]
+files = ["pubspec.yaml"]
+ecosystems = ["dart"]
+
+[commands]
+run = "dart format ."
+alternatives = ["dart format --set-exit-if-changed ."]

--- a/knowledge/dart/dart-test.toml
+++ b/knowledge/dart/dart-test.toml
@@ -1,0 +1,15 @@
+[tool]
+name = "dart test"
+category = "test"
+default = true
+homepage = "https://dart.dev/guides/testing"
+docs = "https://dart.dev/guides/testing"
+description = "Built-in Dart test runner"
+
+[detect]
+files = ["test/", "pubspec.yaml"]
+ecosystems = ["dart"]
+
+[commands]
+run = "dart test"
+alternatives = ["flutter test"]

--- a/knowledge/deno/deno-doc.toml
+++ b/knowledge/deno/deno-doc.toml
@@ -1,0 +1,14 @@
+[tool]
+name = "deno doc"
+category = "docs"
+default = true
+homepage = "https://docs.deno.com/runtime/reference/cli/doc/"
+docs = "https://docs.deno.com/runtime/reference/cli/doc/"
+description = "Built-in Deno documentation generator"
+
+[detect]
+files = ["deno.json", "deno.jsonc"]
+ecosystems = ["deno"]
+
+[commands]
+run = "deno doc"

--- a/knowledge/deno/deno-fmt.toml
+++ b/knowledge/deno/deno-fmt.toml
@@ -1,0 +1,15 @@
+[tool]
+name = "deno fmt"
+category = "format"
+default = true
+homepage = "https://docs.deno.com/runtime/reference/cli/fmt/"
+docs = "https://docs.deno.com/runtime/reference/cli/fmt/"
+description = "Built-in Deno code formatter"
+
+[detect]
+files = ["deno.json", "deno.jsonc"]
+ecosystems = ["deno"]
+
+[commands]
+run = "deno fmt"
+alternatives = ["deno fmt --check"]

--- a/knowledge/deno/deno-lint.toml
+++ b/knowledge/deno/deno-lint.toml
@@ -1,0 +1,14 @@
+[tool]
+name = "deno lint"
+category = "lint"
+default = true
+homepage = "https://docs.deno.com/runtime/reference/cli/lint/"
+docs = "https://docs.deno.com/runtime/reference/cli/lint/"
+description = "Built-in Deno linter"
+
+[detect]
+files = ["deno.json", "deno.jsonc"]
+ecosystems = ["deno"]
+
+[commands]
+run = "deno lint"

--- a/knowledge/deno/deno-test.toml
+++ b/knowledge/deno/deno-test.toml
@@ -1,0 +1,15 @@
+[tool]
+name = "deno test"
+category = "test"
+default = true
+homepage = "https://docs.deno.com/runtime/fundamentals/testing/"
+docs = "https://docs.deno.com/runtime/fundamentals/testing/"
+description = "Built-in Deno test runner"
+
+[detect]
+files = ["deno.json", "deno.jsonc"]
+ecosystems = ["deno"]
+
+[commands]
+run = "deno test"
+alternatives = ["deno test --coverage"]

--- a/knowledge/elixir/credo.toml
+++ b/knowledge/elixir/credo.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "Credo"
 category = "lint"
+default = true
 homepage = "https://hexdocs.pm/credo"
 docs = "https://hexdocs.pm/credo/overview.html"
 repo = "https://github.com/rrrene/credo"

--- a/knowledge/elixir/dialyzer.toml
+++ b/knowledge/elixir/dialyzer.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "Dialyzer"
 category = "typecheck"
+default = true
 homepage = "https://www.erlang.org/doc/apps/dialyzer"
 docs = "https://hexdocs.pm/dialyxir"
 repo = "https://github.com/jeremyjh/dialyxir"

--- a/knowledge/elixir/ex-doc.toml
+++ b/knowledge/elixir/ex-doc.toml
@@ -1,0 +1,15 @@
+[tool]
+name = "ExDoc"
+category = "docs"
+default = true
+homepage = "https://hexdocs.pm/ex_doc"
+docs = "https://hexdocs.pm/ex_doc/readme.html"
+repo = "https://github.com/elixir-lang/ex_doc"
+description = "Documentation generator for Elixir"
+
+[detect]
+dependencies = ["ex_doc"]
+ecosystems = ["elixir"]
+
+[commands]
+run = "mix docs"

--- a/knowledge/elixir/exunit.toml
+++ b/knowledge/elixir/exunit.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "ExUnit"
 category = "test"
+default = true
 homepage = "https://hexdocs.pm/ex_unit"
 docs = "https://hexdocs.pm/ex_unit/ExUnit.html"
 description = "Built-in Elixir test framework"

--- a/knowledge/elixir/mix-format.toml
+++ b/knowledge/elixir/mix-format.toml
@@ -1,0 +1,18 @@
+[tool]
+name = "mix format"
+category = "format"
+default = true
+homepage = "https://hexdocs.pm/mix/Mix.Tasks.Format.html"
+docs = "https://hexdocs.pm/mix/Mix.Tasks.Format.html"
+description = "Built-in Elixir code formatter"
+
+[detect]
+files = [".formatter.exs", "mix.exs"]
+ecosystems = ["elixir"]
+
+[commands]
+run = "mix format"
+alternatives = ["mix format --check-formatted"]
+
+[config]
+files = [".formatter.exs"]

--- a/knowledge/erlang/dialyzer.toml
+++ b/knowledge/erlang/dialyzer.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "Dialyzer"
 category = "typecheck"
+default = true
 homepage = "https://www.erlang.org/doc/apps/dialyzer/"
 docs = "https://www.erlang.org/doc/apps/dialyzer/"
 description = "Static analysis tool for Erlang"

--- a/knowledge/erlang/elvis.toml
+++ b/knowledge/erlang/elvis.toml
@@ -1,0 +1,20 @@
+[tool]
+name = "elvis"
+category = "lint"
+default = true
+homepage = "https://github.com/inaka/elvis"
+docs = "https://github.com/inaka/elvis#readme"
+repo = "https://github.com/inaka/elvis"
+description = "Erlang style reviewer"
+
+[detect]
+files = ["elvis.config"]
+ecosystems = ["erlang"]
+[detect.file_contains]
+"rebar.config" = ["elvis"]
+
+[commands]
+run = "elvis rock"
+
+[config]
+files = ["elvis.config"]

--- a/knowledge/erlang/erlfmt.toml
+++ b/knowledge/erlang/erlfmt.toml
@@ -1,0 +1,20 @@
+[tool]
+name = "erlfmt"
+category = "format"
+default = true
+homepage = "https://github.com/WhatsApp/erlfmt"
+docs = "https://github.com/WhatsApp/erlfmt#readme"
+repo = "https://github.com/WhatsApp/erlfmt"
+description = "Erlang code formatter"
+
+[detect]
+files = [".erlfmt"]
+ecosystems = ["erlang"]
+[detect.file_contains]
+"rebar.config" = ["erlfmt"]
+
+[commands]
+run = "rebar3 fmt"
+
+[config]
+files = [".erlfmt"]

--- a/knowledge/erlang/eunit.toml
+++ b/knowledge/erlang/eunit.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "EUnit"
 category = "test"
+default = true
 homepage = "https://www.erlang.org/doc/apps/eunit/"
 docs = "https://www.erlang.org/doc/apps/eunit/"
 description = "Erlang unit testing framework"

--- a/knowledge/gleam/gleam-format.toml
+++ b/knowledge/gleam/gleam-format.toml
@@ -1,0 +1,15 @@
+[tool]
+name = "gleam format"
+category = "format"
+default = true
+homepage = "https://gleam.run/writing-gleam/command-line-reference/#gleam-format"
+docs = "https://gleam.run/writing-gleam/command-line-reference/#gleam-format"
+description = "Built-in Gleam code formatter"
+
+[detect]
+files = ["gleam.toml"]
+ecosystems = ["gleam"]
+
+[commands]
+run = "gleam format"
+alternatives = ["gleam format --check"]

--- a/knowledge/gleam/gleam-test.toml
+++ b/knowledge/gleam/gleam-test.toml
@@ -1,0 +1,14 @@
+[tool]
+name = "gleam test"
+category = "test"
+default = true
+homepage = "https://gleam.run/writing-gleam/command-line-reference/#gleam-test"
+docs = "https://gleam.run/writing-gleam/command-line-reference/#gleam-test"
+description = "Built-in Gleam test runner"
+
+[detect]
+files = ["gleam.toml"]
+ecosystems = ["gleam"]
+
+[commands]
+run = "gleam test"

--- a/knowledge/go/gocover.toml
+++ b/knowledge/go/gocover.toml
@@ -1,0 +1,15 @@
+[tool]
+name = "go test -cover"
+category = "coverage"
+default = true
+homepage = "https://go.dev/blog/cover"
+docs = "https://go.dev/doc/build-cover"
+description = "Built-in Go coverage profiling"
+
+[detect]
+files = ["go.mod"]
+ecosystems = ["go"]
+
+[commands]
+run = "go test -coverprofile=coverage.out ./..."
+alternatives = ["go tool cover -html=coverage.out"]

--- a/knowledge/go/godoc.toml
+++ b/knowledge/go/godoc.toml
@@ -1,0 +1,15 @@
+[tool]
+name = "pkgsite"
+category = "docs"
+default = true
+homepage = "https://pkg.go.dev"
+docs = "https://pkg.go.dev/golang.org/x/pkgsite/cmd/pkgsite"
+repo = "https://github.com/golang/pkgsite"
+description = "Go documentation server"
+
+[detect]
+files = ["go.mod"]
+ecosystems = ["go"]
+
+[commands]
+run = "go run golang.org/x/pkgsite/cmd/pkgsite@latest"

--- a/knowledge/go/gofmt.toml
+++ b/knowledge/go/gofmt.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "gofmt"
 category = "format"
+default = true
 homepage = "https://pkg.go.dev/cmd/gofmt"
 docs = "https://pkg.go.dev/cmd/gofmt"
 description = "Built-in Go code formatter"

--- a/knowledge/go/golangci-lint.toml
+++ b/knowledge/go/golangci-lint.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "golangci-lint"
 category = "lint"
+default = true
 homepage = "https://golangci-lint.run"
 docs = "https://golangci-lint.run/usage/quick-start/"
 repo = "https://github.com/golangci/golangci-lint"

--- a/knowledge/go/gotest.toml
+++ b/knowledge/go/gotest.toml
@@ -1,13 +1,14 @@
 [tool]
 name = "go test"
 category = "test"
+default = true
 homepage = "https://go.dev/doc/tutorial/add-a-test"
 docs = "https://pkg.go.dev/testing"
 repo = "https://github.com/golang/go"
 description = "Built-in Go test runner"
 
 [detect]
-files = ["*_test.go"]
+files = ["*_test.go", "**/*_test.go", "go.mod"]
 ecosystems = ["go"]
 
 [commands]

--- a/knowledge/go/govulncheck.toml
+++ b/knowledge/go/govulncheck.toml
@@ -1,0 +1,15 @@
+[tool]
+name = "govulncheck"
+category = "security"
+default = true
+homepage = "https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck"
+docs = "https://go.dev/doc/security/vuln/"
+repo = "https://github.com/golang/vuln"
+description = "Go vulnerability scanner"
+
+[detect]
+files = ["go.mod"]
+ecosystems = ["go"]
+
+[commands]
+run = "govulncheck ./..."

--- a/knowledge/haskell/hlint.toml
+++ b/knowledge/haskell/hlint.toml
@@ -1,0 +1,18 @@
+[tool]
+name = "HLint"
+category = "lint"
+default = true
+homepage = "https://github.com/ndmitchell/hlint"
+docs = "https://github.com/ndmitchell/hlint#readme"
+repo = "https://github.com/ndmitchell/hlint"
+description = "Haskell source code suggestions"
+
+[detect]
+files = [".hlint.yaml"]
+ecosystems = ["haskell"]
+
+[commands]
+run = "hlint ."
+
+[config]
+files = [".hlint.yaml"]

--- a/knowledge/haskell/hspec.toml
+++ b/knowledge/haskell/hspec.toml
@@ -1,0 +1,18 @@
+[tool]
+name = "Hspec"
+category = "test"
+default = true
+homepage = "https://hspec.github.io"
+docs = "https://hspec.github.io"
+repo = "https://github.com/hspec/hspec"
+description = "Testing framework for Haskell"
+
+[detect]
+files = ["test/"]
+ecosystems = ["haskell"]
+[detect.file_contains]
+"package.yaml" = ["hspec"]
+
+[commands]
+run = "cabal test"
+alternatives = ["stack test"]

--- a/knowledge/haskell/ormolu.toml
+++ b/knowledge/haskell/ormolu.toml
@@ -1,0 +1,18 @@
+[tool]
+name = "Ormolu"
+category = "format"
+default = true
+homepage = "https://github.com/tweag/ormolu"
+docs = "https://github.com/tweag/ormolu#readme"
+repo = "https://github.com/tweag/ormolu"
+description = "Haskell code formatter"
+
+[detect]
+ecosystems = ["haskell"]
+[detect.file_contains]
+"package.yaml" = ["ormolu"]
+"cabal.project" = ["ormolu"]
+
+[commands]
+run = "ormolu --mode inplace"
+alternatives = ["ormolu --mode check"]

--- a/knowledge/java/checkstyle.toml
+++ b/knowledge/java/checkstyle.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "Checkstyle"
 category = "lint"
+default = true
 homepage = "https://checkstyle.org"
 docs = "https://checkstyle.org/checks.html"
 repo = "https://github.com/checkstyle/checkstyle"

--- a/knowledge/java/google-java-format.toml
+++ b/knowledge/java/google-java-format.toml
@@ -1,0 +1,18 @@
+[tool]
+name = "google-java-format"
+category = "format"
+default = true
+homepage = "https://github.com/google/google-java-format"
+docs = "https://github.com/google/google-java-format#readme"
+repo = "https://github.com/google/google-java-format"
+description = "Java source code formatter"
+
+[detect]
+ecosystems = ["java"]
+[detect.file_contains]
+"pom.xml" = ["google-java-format"]
+"build.gradle" = ["google-java-format", "googleJavaFormat"]
+"build.gradle.kts" = ["google-java-format", "googleJavaFormat"]
+
+[commands]
+run = "google-java-format --replace"

--- a/knowledge/java/jacoco.toml
+++ b/knowledge/java/jacoco.toml
@@ -1,0 +1,19 @@
+[tool]
+name = "JaCoCo"
+category = "coverage"
+default = true
+homepage = "https://www.jacoco.org/jacoco/"
+docs = "https://www.jacoco.org/jacoco/trunk/doc/"
+repo = "https://github.com/jacoco/jacoco"
+description = "Java code coverage library"
+
+[detect]
+ecosystems = ["java"]
+[detect.file_contains]
+"pom.xml" = ["jacoco-maven-plugin"]
+"build.gradle" = ["jacoco"]
+"build.gradle.kts" = ["jacoco"]
+
+[commands]
+run = "mvn verify"
+alternatives = ["gradle jacocoTestReport"]

--- a/knowledge/java/javadoc.toml
+++ b/knowledge/java/javadoc.toml
@@ -1,0 +1,15 @@
+[tool]
+name = "Javadoc"
+category = "docs"
+default = true
+homepage = "https://docs.oracle.com/en/java/javase/21/javadoc/"
+docs = "https://docs.oracle.com/en/java/javase/21/javadoc/"
+description = "Java API documentation generator"
+
+[detect]
+files = ["pom.xml", "build.gradle", "build.gradle.kts"]
+ecosystems = ["java"]
+
+[commands]
+run = "mvn javadoc:javadoc"
+alternatives = ["gradle javadoc"]

--- a/knowledge/java/junit.toml
+++ b/knowledge/java/junit.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "JUnit"
 category = "test"
+default = true
 homepage = "https://junit.org"
 docs = "https://junit.org/junit5/docs/current/user-guide/"
 repo = "https://github.com/junit-team/junit5"

--- a/knowledge/java/owasp-dependency-check.toml
+++ b/knowledge/java/owasp-dependency-check.toml
@@ -1,0 +1,19 @@
+[tool]
+name = "OWASP Dependency-Check"
+category = "security"
+default = true
+homepage = "https://owasp.org/www-project-dependency-check/"
+docs = "https://jeremylong.github.io/DependencyCheck/"
+repo = "https://github.com/jeremylong/DependencyCheck"
+description = "Java dependency vulnerability scanner"
+
+[detect]
+ecosystems = ["java"]
+[detect.file_contains]
+"pom.xml" = ["dependency-check-maven"]
+"build.gradle" = ["dependency-check"]
+"build.gradle.kts" = ["dependency-check"]
+
+[commands]
+run = "mvn dependency-check:check"
+alternatives = ["gradle dependencyCheckAnalyze"]

--- a/knowledge/kotlin/detekt.toml
+++ b/knowledge/kotlin/detekt.toml
@@ -1,0 +1,22 @@
+[tool]
+name = "detekt"
+category = "lint"
+default = true
+homepage = "https://detekt.dev"
+docs = "https://detekt.dev/docs/intro"
+repo = "https://github.com/detekt/detekt"
+description = "Static code analysis for Kotlin"
+
+[detect]
+files = ["detekt.yml", "config/detekt/detekt.yml"]
+ecosystems = ["kotlin"]
+[detect.file_contains]
+"build.gradle.kts" = ["detekt"]
+"build.gradle" = ["detekt"]
+
+[commands]
+run = "gradle detekt"
+alternatives = ["./gradlew detekt"]
+
+[config]
+files = ["detekt.yml", "config/detekt/detekt.yml"]

--- a/knowledge/kotlin/dokka.toml
+++ b/knowledge/kotlin/dokka.toml
@@ -1,0 +1,18 @@
+[tool]
+name = "Dokka"
+category = "docs"
+default = true
+homepage = "https://github.com/Kotlin/dokka"
+docs = "https://kotlinlang.org/docs/dokka-introduction.html"
+repo = "https://github.com/Kotlin/dokka"
+description = "Documentation engine for Kotlin"
+
+[detect]
+ecosystems = ["kotlin"]
+[detect.file_contains]
+"build.gradle.kts" = ["dokka"]
+"build.gradle" = ["dokka"]
+
+[commands]
+run = "gradle dokkaHtml"
+alternatives = ["./gradlew dokkaHtml"]

--- a/knowledge/kotlin/kotlin-test.toml
+++ b/knowledge/kotlin/kotlin-test.toml
@@ -1,0 +1,18 @@
+[tool]
+name = "kotlin.test"
+category = "test"
+default = true
+homepage = "https://kotlinlang.org/api/latest/kotlin.test/"
+docs = "https://kotlinlang.org/docs/jvm-test-using-junit.html"
+description = "Kotlin test framework"
+
+[detect]
+files = ["src/test/"]
+ecosystems = ["kotlin"]
+[detect.file_contains]
+"build.gradle.kts" = ["kotlin(\"test\")", "kotlin-test"]
+"build.gradle" = ["kotlin-test"]
+
+[commands]
+run = "gradle test"
+alternatives = ["./gradlew test"]

--- a/knowledge/kotlin/ktlint.toml
+++ b/knowledge/kotlin/ktlint.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "ktlint"
 category = "format"
+default = true
 homepage = "https://pinterest.github.io/ktlint/"
 docs = "https://pinterest.github.io/ktlint/latest/"
 repo = "https://github.com/pinterest/ktlint"

--- a/knowledge/nim/nim-test.toml
+++ b/knowledge/nim/nim-test.toml
@@ -1,0 +1,15 @@
+[tool]
+name = "testament"
+category = "test"
+default = true
+homepage = "https://nim-lang.org/docs/testament.html"
+docs = "https://nim-lang.org/docs/testament.html"
+description = "Nim test runner"
+
+[detect]
+files = ["tests/", "*.nimble"]
+ecosystems = ["nim"]
+
+[commands]
+run = "nimble test"
+alternatives = ["testament all"]

--- a/knowledge/nim/nimpretty.toml
+++ b/knowledge/nim/nimpretty.toml
@@ -1,0 +1,14 @@
+[tool]
+name = "nimpretty"
+category = "format"
+default = true
+homepage = "https://nim-lang.org/docs/nimpretty.html"
+docs = "https://nim-lang.org/docs/nimpretty.html"
+description = "Built-in Nim code formatter"
+
+[detect]
+files = ["*.nimble"]
+ecosystems = ["nim"]
+
+[commands]
+run = "nimpretty"

--- a/knowledge/node/docusaurus.toml
+++ b/knowledge/node/docusaurus.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "Docusaurus"
 category = "docs"
+default = true
 homepage = "https://docusaurus.io"
 docs = "https://docusaurus.io/docs"
 repo = "https://github.com/facebook/docusaurus"

--- a/knowledge/node/eslint.toml
+++ b/knowledge/node/eslint.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "ESLint"
 category = "lint"
+default = true
 homepage = "https://eslint.org"
 docs = "https://eslint.org/docs/latest/"
 repo = "https://github.com/eslint/eslint"

--- a/knowledge/node/istanbul.toml
+++ b/knowledge/node/istanbul.toml
@@ -1,0 +1,17 @@
+[tool]
+name = "c8"
+category = "coverage"
+default = true
+homepage = "https://github.com/bcoe/c8"
+docs = "https://github.com/bcoe/c8#readme"
+repo = "https://github.com/bcoe/c8"
+description = "Native V8 code coverage"
+
+[detect]
+dependencies = ["c8"]
+dev_dependencies = ["c8", "nyc", "@istanbuljs/nyc-config-typescript"]
+ecosystems = ["node"]
+
+[commands]
+run = "npx c8 npm test"
+alternatives = ["npx nyc npm test"]

--- a/knowledge/node/jest.toml
+++ b/knowledge/node/jest.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "Jest"
 category = "test"
+default = true
 homepage = "https://jestjs.io"
 docs = "https://jestjs.io/docs/getting-started"
 repo = "https://github.com/jestjs/jest"

--- a/knowledge/node/npm-audit.toml
+++ b/knowledge/node/npm-audit.toml
@@ -1,0 +1,15 @@
+[tool]
+name = "npm audit"
+category = "security"
+default = true
+homepage = "https://docs.npmjs.com/cli/commands/npm-audit"
+docs = "https://docs.npmjs.com/auditing-package-dependencies-for-security-vulnerabilities"
+description = "Node.js dependency vulnerability scanner"
+
+[detect]
+files = ["package-lock.json"]
+ecosystems = ["node"]
+
+[commands]
+run = "npm audit"
+alternatives = ["npm audit --production"]

--- a/knowledge/node/prettier.toml
+++ b/knowledge/node/prettier.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "Prettier"
 category = "format"
+default = true
 homepage = "https://prettier.io"
 docs = "https://prettier.io/docs/en/"
 repo = "https://github.com/prettier/prettier"

--- a/knowledge/node/tsc-typecheck.toml
+++ b/knowledge/node/tsc-typecheck.toml
@@ -1,0 +1,21 @@
+[tool]
+name = "tsc"
+category = "typecheck"
+default = true
+homepage = "https://www.typescriptlang.org"
+docs = "https://www.typescriptlang.org/docs/handbook/compiler-options.html"
+repo = "https://github.com/microsoft/TypeScript"
+description = "TypeScript type checker"
+
+[detect]
+files = ["tsconfig.json"]
+dependencies = ["typescript"]
+dev_dependencies = ["typescript"]
+ecosystems = ["node"]
+
+[commands]
+run = "npx tsc --noEmit"
+alternatives = ["tsc --noEmit"]
+
+[config]
+files = ["tsconfig.json"]

--- a/knowledge/ocaml/alcotest.toml
+++ b/knowledge/ocaml/alcotest.toml
@@ -1,0 +1,17 @@
+[tool]
+name = "Alcotest"
+category = "test"
+default = true
+homepage = "https://github.com/mirage/alcotest"
+docs = "https://mirage.github.io/alcotest/"
+repo = "https://github.com/mirage/alcotest"
+description = "Lightweight OCaml test framework"
+
+[detect]
+ecosystems = ["ocaml"]
+[detect.file_contains]
+"dune-project" = ["alcotest"]
+
+[commands]
+run = "dune test"
+alternatives = ["dune runtest"]

--- a/knowledge/ocaml/ocamlformat.toml
+++ b/knowledge/ocaml/ocamlformat.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "ocamlformat"
 category = "format"
+default = true
 homepage = "https://github.com/ocaml-ppx/ocamlformat"
 docs = "https://github.com/ocaml-ppx/ocamlformat#readme"
 repo = "https://github.com/ocaml-ppx/ocamlformat"

--- a/knowledge/php/php-cs-fixer.toml
+++ b/knowledge/php/php-cs-fixer.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "PHP CS Fixer"
 category = "format"
+default = true
 homepage = "https://cs.symfony.com"
 docs = "https://cs.symfony.com/doc/usage.html"
 repo = "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer"

--- a/knowledge/php/phpcs.toml
+++ b/knowledge/php/phpcs.toml
@@ -1,0 +1,21 @@
+[tool]
+name = "PHP_CodeSniffer"
+category = "lint"
+default = true
+homepage = "https://github.com/PHPCSStandards/PHP_CodeSniffer"
+docs = "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+repo = "https://github.com/PHPCSStandards/PHP_CodeSniffer"
+description = "PHP coding standards linter"
+
+[detect]
+files = ["phpcs.xml", "phpcs.xml.dist", ".phpcs.xml", ".phpcs.xml.dist"]
+dependencies = ["squizlabs/php_codesniffer"]
+dev_dependencies = ["squizlabs/php_codesniffer"]
+ecosystems = ["php"]
+
+[commands]
+run = "vendor/bin/phpcs"
+alternatives = ["phpcs"]
+
+[config]
+files = ["phpcs.xml", "phpcs.xml.dist", ".phpcs.xml", ".phpcs.xml.dist"]

--- a/knowledge/php/phpdoc.toml
+++ b/knowledge/php/phpdoc.toml
@@ -1,0 +1,19 @@
+[tool]
+name = "phpDocumentor"
+category = "docs"
+default = true
+homepage = "https://www.phpdoc.org"
+docs = "https://docs.phpdoc.org"
+repo = "https://github.com/phpDocumentor/phpDocumentor"
+description = "Documentation generator for PHP"
+
+[detect]
+files = ["phpdoc.xml", "phpdoc.dist.xml", ".phpdoc.xml", ".phpdoc.dist.xml"]
+dependencies = ["phpdocumentor/phpdocumentor"]
+ecosystems = ["php"]
+
+[commands]
+run = "vendor/bin/phpdoc"
+
+[config]
+files = ["phpdoc.xml", "phpdoc.dist.xml"]

--- a/knowledge/php/phpstan.toml
+++ b/knowledge/php/phpstan.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "PHPStan"
 category = "typecheck"
+default = true
 homepage = "https://phpstan.org"
 docs = "https://phpstan.org/user-guide/getting-started"
 repo = "https://github.com/phpstan/phpstan"

--- a/knowledge/php/phpunit.toml
+++ b/knowledge/php/phpunit.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "PHPUnit"
 category = "test"
+default = true
 homepage = "https://phpunit.de"
 docs = "https://docs.phpunit.de"
 repo = "https://github.com/sebastianbergmann/phpunit"

--- a/knowledge/python/black.toml
+++ b/knowledge/python/black.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "Black"
 category = "format"
+default = true
 homepage = "https://black.readthedocs.io"
 docs = "https://black.readthedocs.io/en/stable/"
 repo = "https://github.com/psf/black"

--- a/knowledge/python/coveragepy.toml
+++ b/knowledge/python/coveragepy.toml
@@ -1,0 +1,25 @@
+[tool]
+name = "coverage.py"
+category = "coverage"
+default = true
+homepage = "https://coverage.readthedocs.io"
+docs = "https://coverage.readthedocs.io/en/latest/"
+repo = "https://github.com/nedbat/coveragepy"
+description = "Code coverage measurement for Python"
+
+[detect]
+files = [".coveragerc"]
+dependencies = ["coverage", "pytest-cov"]
+dev_dependencies = ["coverage", "pytest-cov"]
+[detect.file_contains]
+"pyproject.toml" = ["[tool.coverage"]
+"setup.cfg" = ["[coverage:"]
+
+ecosystems = ["python"]
+
+[commands]
+run = "coverage run -m pytest"
+alternatives = ["pytest --cov"]
+
+[config]
+files = [".coveragerc", "pyproject.toml", "setup.cfg"]

--- a/knowledge/python/mypy.toml
+++ b/knowledge/python/mypy.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "mypy"
 category = "typecheck"
+default = true
 homepage = "https://mypy-lang.org"
 docs = "https://mypy.readthedocs.io"
 repo = "https://github.com/python/mypy"

--- a/knowledge/python/pip-audit.toml
+++ b/knowledge/python/pip-audit.toml
@@ -1,0 +1,17 @@
+[tool]
+name = "pip-audit"
+category = "security"
+default = true
+homepage = "https://github.com/pypa/pip-audit"
+docs = "https://github.com/pypa/pip-audit#readme"
+repo = "https://github.com/pypa/pip-audit"
+description = "Python dependency vulnerability scanner"
+
+[detect]
+dependencies = ["pip-audit"]
+dev_dependencies = ["pip-audit"]
+ecosystems = ["python"]
+
+[commands]
+run = "pip-audit"
+alternatives = ["pip-audit -r requirements.txt"]

--- a/knowledge/python/pytest.toml
+++ b/knowledge/python/pytest.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "pytest"
 category = "test"
+default = true
 homepage = "https://pytest.org"
 docs = "https://docs.pytest.org"
 repo = "https://github.com/pytest-dev/pytest"

--- a/knowledge/python/ruff.toml
+++ b/knowledge/python/ruff.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "Ruff"
 category = "lint"
+default = true
 homepage = "https://docs.astral.sh/ruff/"
 docs = "https://docs.astral.sh/ruff/"
 repo = "https://github.com/astral-sh/ruff"

--- a/knowledge/python/sphinx.toml
+++ b/knowledge/python/sphinx.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "Sphinx"
 category = "docs"
+default = true
 homepage = "https://www.sphinx-doc.org"
 docs = "https://www.sphinx-doc.org/en/master/usage/quickstart.html"
 repo = "https://github.com/sphinx-doc/sphinx"

--- a/knowledge/ruby/bundler-audit.toml
+++ b/knowledge/ruby/bundler-audit.toml
@@ -1,0 +1,17 @@
+[tool]
+name = "bundler-audit"
+category = "security"
+default = true
+homepage = "https://github.com/rubysec/bundler-audit"
+docs = "https://github.com/rubysec/bundler-audit#readme"
+repo = "https://github.com/rubysec/bundler-audit"
+description = "Ruby dependency vulnerability scanner"
+
+[detect]
+dependencies = ["bundler-audit"]
+dev_dependencies = ["bundler-audit"]
+ecosystems = ["ruby"]
+
+[commands]
+run = "bundle exec bundler-audit check --update"
+alternatives = ["bundler-audit"]

--- a/knowledge/ruby/jekyll.toml
+++ b/knowledge/ruby/jekyll.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "Jekyll"
 category = "docs"
+default = true
 homepage = "https://jekyllrb.com"
 docs = "https://jekyllrb.com/docs/"
 repo = "https://github.com/jekyll/jekyll"

--- a/knowledge/ruby/rspec.toml
+++ b/knowledge/ruby/rspec.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "RSpec"
 category = "test"
+default = true
 homepage = "https://rspec.info"
 docs = "https://rspec.info/documentation"
 repo = "https://github.com/rspec/rspec"

--- a/knowledge/ruby/rubocop.toml
+++ b/knowledge/ruby/rubocop.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "RuboCop"
 category = "lint"
+default = true
 homepage = "https://rubocop.org"
 docs = "https://docs.rubocop.org"
 repo = "https://github.com/rubocop/rubocop"

--- a/knowledge/ruby/simplecov.toml
+++ b/knowledge/ruby/simplecov.toml
@@ -1,0 +1,16 @@
+[tool]
+name = "SimpleCov"
+category = "coverage"
+default = true
+homepage = "https://github.com/simplecov-ruby/simplecov"
+docs = "https://github.com/simplecov-ruby/simplecov#readme"
+repo = "https://github.com/simplecov-ruby/simplecov"
+description = "Code coverage for Ruby"
+
+[detect]
+dependencies = ["simplecov"]
+dev_dependencies = ["simplecov"]
+ecosystems = ["ruby"]
+
+[commands]
+run = "bundle exec rake spec"

--- a/knowledge/ruby/sorbet.toml
+++ b/knowledge/ruby/sorbet.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "Sorbet"
 category = "typecheck"
+default = true
 homepage = "https://sorbet.org"
 docs = "https://sorbet.org/docs/overview"
 repo = "https://github.com/sorbet/sorbet"

--- a/knowledge/ruby/standardrb.toml
+++ b/knowledge/ruby/standardrb.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "StandardRB"
 category = "format"
+default = true
 homepage = "https://github.com/standardrb/standard"
 docs = "https://github.com/standardrb/standard#readme"
 repo = "https://github.com/standardrb/standard"

--- a/knowledge/rust/cargo-audit.toml
+++ b/knowledge/rust/cargo-audit.toml
@@ -1,0 +1,15 @@
+[tool]
+name = "cargo-audit"
+category = "security"
+default = true
+homepage = "https://github.com/rustsec/rustsec"
+docs = "https://github.com/rustsec/rustsec/tree/main/cargo-audit#readme"
+repo = "https://github.com/rustsec/rustsec"
+description = "Rust dependency vulnerability scanner"
+
+[detect]
+files = ["Cargo.toml"]
+ecosystems = ["rust"]
+
+[commands]
+run = "cargo audit"

--- a/knowledge/rust/cargodoc.toml
+++ b/knowledge/rust/cargodoc.toml
@@ -1,0 +1,15 @@
+[tool]
+name = "cargo doc"
+category = "docs"
+default = true
+homepage = "https://doc.rust-lang.org/cargo/commands/cargo-doc.html"
+docs = "https://doc.rust-lang.org/rustdoc/"
+description = "Built-in Rust documentation generator"
+
+[detect]
+files = ["Cargo.toml"]
+ecosystems = ["rust"]
+
+[commands]
+run = "cargo doc"
+alternatives = ["cargo doc --open", "cargo doc --no-deps"]

--- a/knowledge/rust/cargotest.toml
+++ b/knowledge/rust/cargotest.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "cargo test"
 category = "test"
+default = true
 homepage = "https://doc.rust-lang.org/cargo/commands/cargo-test.html"
 docs = "https://doc.rust-lang.org/book/ch11-01-writing-tests.html"
 description = "Built-in Rust test runner"

--- a/knowledge/rust/clippy.toml
+++ b/knowledge/rust/clippy.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "Clippy"
 category = "lint"
+default = true
 homepage = "https://github.com/rust-lang/rust-clippy"
 docs = "https://doc.rust-lang.org/clippy/"
 repo = "https://github.com/rust-lang/rust-clippy"

--- a/knowledge/rust/rustfmt.toml
+++ b/knowledge/rust/rustfmt.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "rustfmt"
 category = "format"
+default = true
 homepage = "https://github.com/rust-lang/rustfmt"
 docs = "https://rust-lang.github.io/rustfmt/"
 repo = "https://github.com/rust-lang/rustfmt"

--- a/knowledge/rust/tarpaulin.toml
+++ b/knowledge/rust/tarpaulin.toml
@@ -1,0 +1,19 @@
+[tool]
+name = "cargo-tarpaulin"
+category = "coverage"
+default = true
+homepage = "https://github.com/xd009642/tarpaulin"
+docs = "https://github.com/xd009642/tarpaulin#readme"
+repo = "https://github.com/xd009642/tarpaulin"
+description = "Rust code coverage tool"
+
+[detect]
+ecosystems = ["rust"]
+[detect.file_contains]
+".github/workflows/ci.yml" = ["tarpaulin"]
+".github/workflows/ci.yaml" = ["tarpaulin"]
+"Cargo.toml" = ["cargo-tarpaulin"]
+
+[commands]
+run = "cargo tarpaulin"
+alternatives = ["cargo tarpaulin --out html"]

--- a/knowledge/scala/scalafmt.toml
+++ b/knowledge/scala/scalafmt.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "scalafmt"
 category = "format"
+default = true
 homepage = "https://scalameta.org/scalafmt/"
 docs = "https://scalameta.org/scalafmt/docs/installation.html"
 repo = "https://github.com/scalameta/scalafmt"

--- a/knowledge/scala/scalatest.toml
+++ b/knowledge/scala/scalatest.toml
@@ -1,0 +1,17 @@
+[tool]
+name = "ScalaTest"
+category = "test"
+default = true
+homepage = "https://www.scalatest.org"
+docs = "https://www.scalatest.org/user_guide"
+repo = "https://github.com/scalatest/scalatest"
+description = "Testing framework for Scala"
+
+[detect]
+files = ["src/test/scala/"]
+ecosystems = ["scala"]
+[detect.file_contains]
+"build.sbt" = ["scalatest", "ScalaTest"]
+
+[commands]
+run = "sbt test"

--- a/knowledge/scala/wartremover.toml
+++ b/knowledge/scala/wartremover.toml
@@ -1,0 +1,17 @@
+[tool]
+name = "WartRemover"
+category = "lint"
+default = true
+homepage = "https://www.wartremover.org"
+docs = "https://www.wartremover.org"
+repo = "https://github.com/wartremover/wartremover"
+description = "Flexible Scala linter"
+
+[detect]
+ecosystems = ["scala"]
+[detect.file_contains]
+"build.sbt" = ["wartremover", "WartRemover"]
+"project/plugins.sbt" = ["wartremover"]
+
+[commands]
+run = "sbt compile"

--- a/knowledge/swift/swiftformat.toml
+++ b/knowledge/swift/swiftformat.toml
@@ -1,6 +1,7 @@
 [tool]
 name = "SwiftFormat"
 category = "format"
+default = true
 homepage = "https://github.com/nicklockwood/SwiftFormat"
 docs = "https://github.com/nicklockwood/SwiftFormat#readme"
 repo = "https://github.com/nicklockwood/SwiftFormat"

--- a/knowledge/swift/swiftlint.toml
+++ b/knowledge/swift/swiftlint.toml
@@ -1,0 +1,19 @@
+[tool]
+name = "SwiftLint"
+category = "lint"
+default = true
+homepage = "https://realm.github.io/SwiftLint/"
+docs = "https://realm.github.io/SwiftLint/"
+repo = "https://github.com/realm/SwiftLint"
+description = "Linter for Swift code"
+
+[detect]
+files = [".swiftlint.yml", ".swiftlint.yaml"]
+ecosystems = ["swift"]
+
+[commands]
+run = "swiftlint"
+alternatives = ["swiftlint lint", "swiftlint --strict"]
+
+[config]
+files = [".swiftlint.yml", ".swiftlint.yaml"]

--- a/knowledge/swift/xctest.toml
+++ b/knowledge/swift/xctest.toml
@@ -1,0 +1,15 @@
+[tool]
+name = "XCTest"
+category = "test"
+default = true
+homepage = "https://developer.apple.com/documentation/xctest"
+docs = "https://developer.apple.com/documentation/xctest"
+description = "Apple's testing framework for Swift"
+
+[detect]
+files = ["Package.swift", "*.xcodeproj/"]
+ecosystems = ["swift"]
+
+[commands]
+run = "swift test"
+alternatives = ["xcodebuild test"]

--- a/knowledge/zig/zig-fmt.toml
+++ b/knowledge/zig/zig-fmt.toml
@@ -1,0 +1,15 @@
+[tool]
+name = "zig fmt"
+category = "format"
+default = true
+homepage = "https://ziglang.org/documentation/master/#zig-fmt"
+docs = "https://ziglang.org/documentation/master/#zig-fmt"
+description = "Built-in Zig code formatter"
+
+[detect]
+files = ["build.zig"]
+ecosystems = ["zig"]
+
+[commands]
+run = "zig fmt ."
+alternatives = ["zig fmt --check ."]

--- a/knowledge/zig/zig-test.toml
+++ b/knowledge/zig/zig-test.toml
@@ -1,0 +1,14 @@
+[tool]
+name = "zig test"
+category = "test"
+default = true
+homepage = "https://ziglang.org/documentation/master/#Zig-Test"
+docs = "https://ziglang.org/documentation/master/#Zig-Test"
+description = "Built-in Zig test runner"
+
+[detect]
+files = ["build.zig"]
+ecosystems = ["zig"]
+
+[commands]
+run = "zig build test"

--- a/report/report.go
+++ b/report/report.go
@@ -361,6 +361,39 @@ func Human(w io.Writer, r *brief.Report, verbose bool) {
 		r.Stats.DurationMS, r.Stats.FilesChecked, r.Stats.ToolsMatched, r.Stats.ToolsChecked)
 }
 
+// MissingJSON writes the missing report as JSON.
+func MissingJSON(w io.Writer, r *brief.MissingReport) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(r)
+}
+
+// MissingHuman writes the missing report in human-readable format.
+func MissingHuman(w io.Writer, r *brief.MissingReport) {
+	if len(r.Missing) == 0 {
+		_, _ = fmt.Fprintf(w, "No missing recommended tooling detected.\n")
+		return
+	}
+
+	_, _ = fmt.Fprintf(w, "Detected: %s\n\n", strings.Join(r.Ecosystems, ", "))
+	_, _ = fmt.Fprintf(w, "Missing recommended tooling:\n\n")
+
+	for _, m := range r.Missing {
+		_, _ = fmt.Fprintf(w, "  %-12s No %s tool configured\n", m.Label, strings.ToLower(m.Label))
+		if m.Suggested != "" {
+			line := "Suggested: " + m.Suggested
+			if m.SuggestedCmd != "" {
+				line += " (" + sanitize(m.SuggestedCmd) + ")"
+			}
+			_, _ = fmt.Fprintf(w, "  %-12s %s\n", "", line)
+		}
+		if m.Docs != "" {
+			_, _ = fmt.Fprintf(w, "  %-12s %s\n", "", sanitize(m.Docs))
+		}
+		_, _ = fmt.Fprintln(w)
+	}
+}
+
 func printResource(w io.Writer, value string) {
 	if value != "" {
 		_, _ = fmt.Fprintf(w, "Resources:   %s\n", value)


### PR DESCRIPTION
Add `brief missing` command that reports recommended tool categories not detected in a project, with suggested defaults per ecosystem. Recommended categories: test, lint, format, typecheck, docs.

Add `default = true` flag to tool TOML definitions so the missing command suggests the canonical tool per ecosystem (pytest for Python, ESLint for Node, etc).

Add 60+ new tool definitions across 17 ecosystems covering test, lint, format, docs, security, and coverage categories for Go, Rust, Node, Python, Ruby, Java, Kotlin, Elixir, PHP, Swift, Dart, C#, C/C++, Scala, Deno, Erlang, Haskell, Crystal, Clojure, Zig, Nim, and Gleam.