### PR TITLE
Fix all golangci-lint issues

### DIFF
--- a/brief.go
+++ b/brief.go
@@ -25,6 +25,14 @@ const (
 	SourceConfigFile    Source = "config_file"
 )
 
+// Scope values for DepInfo.
+const (
+	ScopeRuntime     = "runtime"
+	ScopeDevelopment = "development"
+	ScopeTest        = "test"
+	ScopeBuild       = "build"
+)
+
 // Command is a runnable command with provenance.
 type Command struct {
 	Run          string   `json:"run"`

--- a/cmd/brief/diff.go
+++ b/cmd/brief/diff.go
@@ -48,7 +48,7 @@ func cmdDiff(args []string) {
 		ref1 = fs.Arg(0)
 		includeUncommitted = true
 		diffRef = ref1 + " (+ uncommitted)"
-	case 2:
+	case 2: //nolint:mnd // two refs
 		ref1 = fs.Arg(0)
 		ref2 = fs.Arg(1)
 		diffRef = ref1 + ".." + ref2

--- a/cmd/brief/enrich.go
+++ b/cmd/brief/enrich.go
@@ -47,37 +47,43 @@ func cmdEnrich(args []string) {
 		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
-	defer src.Cleanup()
 
+	code := runEnrich(src.Dir, *scanDepth, *skip, *jsonFlag, *humanFlag, *verbose)
+	src.Cleanup()
+	os.Exit(code)
+}
+
+func runEnrich(dir string, scanDepth int, skip string, jsonFlag, humanFlag, verbose bool) int {
 	knowledgeBase, err := kb.Load(brief.KnowledgeFS)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "error loading knowledge base: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
 
-	engine := detect.New(knowledgeBase, src.Dir)
-	engine.ScanDepth = *scanDepth
-	if *skip != "" {
-		engine.SkipDirs = strings.Split(*skip, ",")
+	engine := detect.New(knowledgeBase, dir)
+	engine.ScanDepth = scanDepth
+	if skip != "" {
+		engine.SkipDirs = strings.Split(skip, ",")
 	}
 	r, err := engine.Run()
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
 
 	ctx := context.Background()
-	r.Enrichment = enrich(ctx, r, src.Dir)
+	r.Enrichment = enrich(ctx, r, dir)
 
-	useJSON := *jsonFlag || (!*humanFlag && !isTTY())
+	useJSON := jsonFlag || (!humanFlag && !isTTY())
 	if useJSON {
 		if err := report.JSON(os.Stdout, r); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "error writing JSON: %v\n", err)
-			os.Exit(1)
+			return 1
 		}
 	} else {
-		report.Human(os.Stdout, r, *verbose)
+		report.Human(os.Stdout, r, verbose)
 	}
+	return 0
 }
 
 func enrich(ctx context.Context, r *brief.Report, root string) *brief.EnrichmentInfo {
@@ -87,7 +93,7 @@ func enrich(ctx context.Context, r *brief.Report, root string) *brief.Enrichment
 	var mu sync.Mutex
 
 	// Published packages
-	purls := detectPublishedPURLs(root, r)
+	purls := detectPublishedPURLs(root)
 	if len(purls) > 0 {
 		wg.Add(1)
 		go func() {
@@ -124,7 +130,7 @@ func enrich(ctx context.Context, r *brief.Report, root string) *brief.Enrichment
 
 // detectPublishedPURLs figures out what packages this repo publishes by
 // reading the project's own identity from manifest files.
-func detectPublishedPURLs(root string, r *brief.Report) []string {
+func detectPublishedPURLs(root string) []string {
 	var purls []string
 
 	// Go module
@@ -207,7 +213,7 @@ func pythonPackagePURL(root string) string {
 		for _, line := range strings.Split(string(data), "\n") {
 			line = strings.TrimSpace(line)
 			if strings.HasPrefix(line, "name") && strings.Contains(line, "=") {
-				parts := strings.SplitN(line, "=", 2)
+				parts := strings.SplitN(line, "=", 2) //nolint:mnd // key=value split
 				name := strings.TrimSpace(parts[1])
 				if name != "" {
 					return "pkg:pypi/" + name
@@ -424,8 +430,8 @@ func productFromFile(file string) string {
 
 func majorMinor(version string) string {
 	version = strings.TrimSpace(version)
-	parts := strings.SplitN(version, ".", 3)
-	if len(parts) < 2 {
+	parts := strings.SplitN(version, ".", 3) //nolint:mnd // major.minor.patch
+	if len(parts) < 2 {                      //nolint:mnd // need at least major.minor
 		return version
 	}
 	return parts[0] + "." + parts[1]

--- a/cmd/brief/main.go
+++ b/cmd/brief/main.go
@@ -79,39 +79,45 @@ func cmdScan(args []string) {
 		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
-	defer src.Cleanup()
 
+	code := runScan(src.Dir, *scanDepth, *skip, *category, *jsonFlag, *humanFlag, *verbose)
+	src.Cleanup()
+	os.Exit(code)
+}
+
+func runScan(dir string, scanDepth int, skip, category string, jsonFlag, humanFlag, verbose bool) int {
 	knowledgeBase, err := kb.Load(brief.KnowledgeFS)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "error loading knowledge base: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
 
-	engine := detect.New(knowledgeBase, src.Dir)
-	engine.ScanDepth = *scanDepth
-	if *skip != "" {
-		engine.SkipDirs = strings.Split(*skip, ",")
+	engine := detect.New(knowledgeBase, dir)
+	engine.ScanDepth = scanDepth
+	if skip != "" {
+		engine.SkipDirs = strings.Split(skip, ",")
 	}
 	r, err := engine.Run()
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
 
-	if *category != "" {
-		r = filterCategory(r, *category)
+	if category != "" {
+		r = filterCategory(r, category)
 	}
 
-	useJSON := *jsonFlag || (!*humanFlag && !isTTY())
+	useJSON := jsonFlag || (!humanFlag && !isTTY())
 
 	if useJSON {
 		if err := report.JSON(os.Stdout, r); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "error writing JSON: %v\n", err)
-			os.Exit(1)
+			return 1
 		}
 	} else {
-		report.Human(os.Stdout, r, *verbose)
+		report.Human(os.Stdout, r, verbose)
 	}
+	return 0
 }
 
 func cmdList(args []string) {

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -22,6 +22,16 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const (
+	defaultScanDepth = 4      // max directory depth for language detection
+	microsPerMS      = 1000.0 // microseconds per millisecond
+	globSplitParts   = 2      // expected parts when splitting "**/" patterns
+
+	rankHigh   = 3
+	rankMedium = 2
+	rankLow    = 1
+)
+
 // Engine runs detection against a project directory.
 type Engine struct {
 	KB           *kb.KnowledgeBase
@@ -142,69 +152,11 @@ func (e *Engine) Run() (*brief.Report, error) {
 
 	report.Languages = e.detectCategory("language")
 	e.sortLanguagesByFileCount(report)
-
-	// Build set of detected ecosystems from language results to filter
-	// ecosystem-specific tools (prevents ExUnit matching in JS projects, etc.)
-	e.detectedEcosystems = make(map[string]bool)
-	for _, lang := range report.Languages {
-		for _, tool := range e.KB.Tools {
-			if tool.Tool.Name == lang.Name && tool.Tool.Category == "language" {
-				for _, eco := range tool.Detect.Ecosystems {
-					e.detectedEcosystems[eco] = true
-				}
-			}
-		}
-	}
+	e.buildEcosystemSet(report)
 
 	report.PackageManagers = e.detectCategory("package_manager")
 	report.Scripts = e.detectScripts()
-
-	// Build a map of script names to their commands for linking
-	scriptsByName := make(map[string]brief.Script)
-	for _, s := range report.Scripts {
-		scriptsByName[s.Name] = s
-	}
-
-	// Category names that map to common script names
-	categoryScriptNames := map[string][]string{
-		"test":      {"test", "spec"},
-		"lint":      {"lint", "check"},
-		"format":    {"format", "fmt"},
-		"typecheck": {"typecheck", "types", "type-check"},
-		"build":     {"build", "compile"},
-		"docs":      {"docs", "doc"},
-	}
-
-	for _, cat := range e.KB.Categories() {
-		if cat == "language" || cat == "package_manager" {
-			continue
-		}
-		detections := e.detectCategory(cat)
-		if len(detections) == 0 {
-			continue
-		}
-
-		// Link project scripts to detected tools
-		if scriptNames, ok := categoryScriptNames[cat]; ok {
-			for _, sn := range scriptNames {
-				script, exists := scriptsByName[sn]
-				if !exists {
-					continue
-				}
-				// Override the first tool's command with the project script
-				if detections[0].Command != nil {
-					detections[0].Command = &brief.Command{
-						Run:          script.Run,
-						Source:       brief.SourceProjectScript,
-						InferredTool: detections[0].Name,
-					}
-				}
-				break
-			}
-		}
-
-		report.Tools[cat] = detections
-	}
+	e.detectTools(report)
 
 	report.Style = e.detectStyle()
 	report.Layout = e.detectLayout()
@@ -212,15 +164,17 @@ func (e *Engine) Run() (*brief.Report, error) {
 
 	// Run slow detections concurrently.
 	var wg sync.WaitGroup
-	wg.Add(3)
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		report.Resources = e.detectResources()
 	}()
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		report.Git = e.detectGit(abs)
 	}()
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		report.Lines = e.detectLineCount(abs)
@@ -234,13 +188,80 @@ func (e *Engine) Run() (*brief.Report, error) {
 	elapsed := time.Since(start)
 	report.Stats = brief.Stats{
 		Duration:     elapsed,
-		DurationMS:   float64(elapsed.Microseconds()) / 1000.0,
+		DurationMS:   float64(elapsed.Microseconds()) / microsPerMS,
 		FilesChecked: e.filesChecked,
 		ToolsMatched: e.toolsMatched,
 		ToolsChecked: e.toolsChecked,
 	}
 
 	return report, nil
+}
+
+// buildEcosystemSet populates detectedEcosystems from language results to filter
+// ecosystem-specific tools (prevents ExUnit matching in JS projects, etc.)
+func (e *Engine) buildEcosystemSet(report *brief.Report) {
+	e.detectedEcosystems = make(map[string]bool)
+	for _, lang := range report.Languages {
+		for _, tool := range e.KB.Tools {
+			if tool.Tool.Name == lang.Name && tool.Tool.Category == "language" {
+				for _, eco := range tool.Detect.Ecosystems {
+					e.detectedEcosystems[eco] = true
+				}
+			}
+		}
+	}
+}
+
+// categoryScriptNames maps tool categories to common script names.
+var categoryScriptNames = map[string][]string{
+	"test":      {"test", "spec"},
+	"lint":      {"lint", "check"},
+	"format":    {"format", "fmt"},
+	"typecheck": {"typecheck", "types", "type-check"},
+	"build":     {"build", "compile"},
+	"docs":      {"docs", "doc"},
+}
+
+// detectTools detects all tool categories and links project scripts.
+func (e *Engine) detectTools(report *brief.Report) {
+	scriptsByName := make(map[string]brief.Script)
+	for _, s := range report.Scripts {
+		scriptsByName[s.Name] = s
+	}
+
+	for _, cat := range e.KB.Categories() {
+		if cat == "language" || cat == "package_manager" {
+			continue
+		}
+		detections := e.detectCategory(cat)
+		if len(detections) == 0 {
+			continue
+		}
+		linkScriptToTool(detections, cat, scriptsByName)
+		report.Tools[cat] = detections
+	}
+}
+
+// linkScriptToTool overrides a tool's command with a matching project script.
+func linkScriptToTool(detections []brief.Detection, cat string, scriptsByName map[string]brief.Script) {
+	scriptNames, ok := categoryScriptNames[cat]
+	if !ok {
+		return
+	}
+	for _, sn := range scriptNames {
+		script, exists := scriptsByName[sn]
+		if !exists {
+			continue
+		}
+		if detections[0].Command != nil {
+			detections[0].Command = &brief.Command{
+				Run:          script.Run,
+				Source:       brief.SourceProjectScript,
+				InferredTool: detections[0].Name,
+			}
+		}
+		break
+	}
 }
 
 // detectCategory finds all tools in a given category that match the project.
@@ -368,8 +389,8 @@ func (e *Engine) exists(pattern string) bool {
 // recursiveGlob handles ** patterns by checking against the cached file extension set.
 // Falls back to a bounded walk if the cache isn't populated.
 func (e *Engine) recursiveGlob(pattern string) bool {
-	parts := strings.SplitN(pattern, "**/", 2)
-	if len(parts) != 2 {
+	parts := strings.SplitN(pattern, "**/", globSplitParts)
+	if len(parts) != globSplitParts {
 		return false
 	}
 	suffix := parts[1] // e.g. "*.py"
@@ -416,7 +437,7 @@ func (e *Engine) loadFileExts() {
 	e.fileExts = make(map[string]int)
 	maxDepth := e.ScanDepth
 	if maxDepth == 0 {
-		maxDepth = 4
+		maxDepth = defaultScanDepth
 	}
 	rootLen := len(e.Root)
 	_ = filepath.Walk(e.Root, func(path string, info os.FileInfo, err error) error {
@@ -533,14 +554,14 @@ func (e *Engine) loadDeps() {
 			if !dep.Direct && !isResolved {
 				continue
 			}
-			scope := "runtime"
+			scope := brief.ScopeRuntime
 			switch dep.Scope {
 			case manifests.Development:
-				scope = "development"
+				scope = brief.ScopeDevelopment
 			case manifests.Test:
-				scope = "test"
+				scope = brief.ScopeTest
 			case manifests.Build:
-				scope = "build"
+				scope = brief.ScopeBuild
 			}
 			e.parsedDeps = append(e.parsedDeps, brief.DepInfo{
 				Name:    dep.Name,
@@ -779,6 +800,57 @@ func (e *Engine) detectStyle() *brief.StyleInfo {
 	return style
 }
 
+// styleCounts tracks indentation and line ending counts during sampling.
+type styleCounts struct {
+	tabs, spaces2, spaces4 int
+	lf, crlf               int
+	sampled                int
+}
+
+func (sc *styleCounts) addFile(data []byte) {
+	sc.sampled++
+	content := string(data)
+	for _, line := range strings.Split(content, "\n") {
+		if len(line) == 0 {
+			continue
+		}
+		switch {
+		case line[0] == '\t':
+			sc.tabs++
+		case strings.HasPrefix(line, "    "):
+			sc.spaces4++
+		case strings.HasPrefix(line, "  ") && !strings.HasPrefix(line, "   "):
+			sc.spaces2++
+		}
+	}
+	if strings.Contains(content, "\r\n") {
+		sc.crlf++
+	} else {
+		sc.lf++
+	}
+}
+
+func (sc *styleCounts) toStyleInfo() *brief.StyleInfo {
+	if sc.sampled == 0 {
+		return nil
+	}
+	style := &brief.StyleInfo{IndentSource: "inferred"}
+	switch {
+	case sc.tabs > sc.spaces2 && sc.tabs > sc.spaces4:
+		style.Indentation = "tabs"
+	case sc.spaces2 > sc.spaces4:
+		style.Indentation = "2-space"
+	case sc.spaces4 > 0:
+		style.Indentation = "4-space"
+	}
+	if sc.crlf > sc.lf {
+		style.LineEnding = "CRLF"
+	} else if sc.lf > 0 {
+		style.LineEnding = "LF"
+	}
+	return style
+}
+
 // inferStyle samples source files to detect indentation style.
 func (e *Engine) inferStyle() *brief.StyleInfo {
 	if e.KB.StyleConfig == nil {
@@ -790,90 +862,39 @@ func (e *Engine) inferStyle() *brief.StyleInfo {
 		limit = 10
 	}
 
-	tabs, spaces2, spaces4 := 0, 0, 0
-	lf, crlf := 0, 0
-	sampled := 0
-
 	exts := make(map[string]bool, len(e.KB.StyleConfig.Style.SampleExts))
 	for _, ext := range e.KB.StyleConfig.Style.SampleExts {
 		exts[ext] = true
 	}
 
+	var sc styleCounts
 	errDone := errors.New("done")
 	_ = filepath.Walk(e.Root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil
 		}
 		if info.IsDir() {
-			// Skip hidden and vendor directories
 			name := info.Name()
 			if name != "." && e.shouldSkipDir(name) {
 				return filepath.SkipDir
 			}
 			return nil
 		}
-		if sampled >= limit {
+		if sc.sampled >= limit {
 			return errDone
 		}
-
-		ext := filepath.Ext(path)
-		if !exts[ext] {
+		if !exts[filepath.Ext(path)] {
 			return nil
 		}
-
 		data, err := os.ReadFile(path)
 		if err != nil {
 			return nil
 		}
-
-		sampled++
-		content := string(data)
-		lines := strings.Split(content, "\n")
-
-		for _, line := range lines {
-			if len(line) == 0 {
-				continue
-			}
-			if line[0] == '\t' {
-				tabs++
-			} else if strings.HasPrefix(line, "    ") {
-				spaces4++
-			} else if strings.HasPrefix(line, "  ") && !strings.HasPrefix(line, "   ") {
-				spaces2++
-			}
-		}
-
-		if strings.Contains(content, "\r\n") {
-			crlf++
-		} else {
-			lf++
-		}
-
+		sc.addFile(data)
 		return nil
 	})
 
-	if sampled == 0 {
-		return nil
-	}
-
-	style := &brief.StyleInfo{IndentSource: "inferred"}
-
-	switch {
-	case tabs > spaces2 && tabs > spaces4:
-		style.Indentation = "tabs"
-	case spaces2 > spaces4:
-		style.Indentation = "2-space"
-	case spaces4 > 0:
-		style.Indentation = "4-space"
-	}
-
-	if crlf > lf {
-		style.LineEnding = "CRLF"
-	} else if lf > 0 {
-		style.LineEnding = "LF"
-	}
-
-	return style
+	return sc.toStyleInfo()
 }
 
 // detectLayout checks for source and test directory patterns from the knowledge base.
@@ -985,65 +1006,72 @@ func (e *Engine) parseCIMatrices(platforms *brief.PlatformInfo) {
 		if err != nil {
 			continue
 		}
-
 		for _, path := range matches {
-			rel, err := filepath.Rel(e.Root, path)
-			if err != nil {
-				continue
-			}
-			data, err := e.safeReadFile(rel)
-			if err != nil {
-				continue
-			}
+			e.parseCIWorkflow(path, ci.MatrixKeys, platforms)
+		}
+	}
+}
 
-			var workflow map[string]any
-			if err := yaml.Unmarshal(data, &workflow); err != nil {
-				continue
-			}
+func (e *Engine) parseCIWorkflow(path string, matrixKeys map[string]string, platforms *brief.PlatformInfo) {
+	rel, err := filepath.Rel(e.Root, path)
+	if err != nil {
+		return
+	}
+	data, err := e.safeReadFile(rel)
+	if err != nil {
+		return
+	}
 
-			jobs, ok := workflow["jobs"].(map[string]any)
+	var workflow map[string]any
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		return
+	}
+
+	jobs, ok := workflow["jobs"].(map[string]any)
+	if !ok {
+		return
+	}
+
+	for _, job := range jobs {
+		matrix := extractJobMatrix(job)
+		if matrix == nil {
+			continue
+		}
+		for ourKey, ciKey := range matrixKeys {
+			values, ok := matrix[ciKey]
 			if !ok {
 				continue
 			}
-
-			for _, job := range jobs {
-				jobMap, ok := job.(map[string]any)
-				if !ok {
-					continue
-				}
-
-				strategy, ok := jobMap["strategy"].(map[string]any)
-				if !ok {
-					continue
-				}
-
-				matrix, ok := strategy["matrix"].(map[string]any)
-				if !ok {
-					continue
-				}
-
-				for ourKey, ciKey := range ci.MatrixKeys {
-					values, ok := matrix[ciKey]
-					if !ok {
-						continue
-					}
-
-					versions := toStringSlice(values)
-					if len(versions) == 0 {
-						continue
-					}
-
-					if ourKey == "os" {
-						platforms.CIMatrixOS = append(platforms.CIMatrixOS, versions...)
-					} else {
-						platforms.CIMatrixVersions[ourKey] = append(
-							platforms.CIMatrixVersions[ourKey], versions...,
-						)
-					}
-				}
+			versions := toStringSlice(values)
+			if len(versions) == 0 {
+				continue
+			}
+			if ourKey == "os" {
+				platforms.CIMatrixOS = append(platforms.CIMatrixOS, versions...)
+			} else {
+				platforms.CIMatrixVersions[ourKey] = append(
+					platforms.CIMatrixVersions[ourKey], versions...,
+				)
 			}
 		}
 	}
+}
+
+// extractJobMatrix pulls the strategy.matrix map from a job definition.
+func extractJobMatrix(job any) map[string]any {
+	jobMap, ok := job.(map[string]any)
+	if !ok {
+		return nil
+	}
+	strategy, ok := jobMap["strategy"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	matrix, ok := strategy["matrix"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	return matrix
 }
 
 // toStringSlice converts a YAML value (string or []any) to []string.
@@ -1090,8 +1118,7 @@ func (e *Engine) detectGit(absPath string) *brief.GitInfo {
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 
-	wg.Add(4)
-
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		if out, err := e.git(absPath, "branch", "--show-current"); err == nil {
@@ -1101,6 +1128,7 @@ func (e *Engine) detectGit(absPath string) *brief.GitInfo {
 		}
 	}()
 
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		if out, err := e.git(absPath, "rev-parse", "--abbrev-ref", "origin/HEAD"); err == nil {
@@ -1113,6 +1141,7 @@ func (e *Engine) detectGit(absPath string) *brief.GitInfo {
 		}
 	}()
 
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		if out, err := e.git(absPath, "remote"); err == nil {
@@ -1126,6 +1155,7 @@ func (e *Engine) detectGit(absPath string) *brief.GitInfo {
 		}
 	}()
 
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		if out, err := e.git(absPath, "rev-list", "--count", "HEAD"); err == nil {
@@ -1335,15 +1365,12 @@ func (e *Engine) Missing(r *brief.Report) *brief.MissingReport {
 	return mr
 }
 
+var confidenceRank = map[brief.Confidence]int{
+	brief.ConfidenceHigh:   rankHigh,
+	brief.ConfidenceMedium: rankMedium,
+	brief.ConfidenceLow:    rankLow,
+}
+
 func rank(c brief.Confidence) int {
-	switch c {
-	case brief.ConfidenceHigh:
-		return 3
-	case brief.ConfidenceMedium:
-		return 2
-	case brief.ConfidenceLow:
-		return 1
-	default:
-		return 0
-	}
+	return confidenceRank[c]
 }

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -16,22 +16,28 @@ func loadKB(t *testing.T) *kb.KnowledgeBase {
 	return knowledgeBase
 }
 
-func TestRubyProject(t *testing.T) {
+func rubyReport(t *testing.T) *brief.Report {
+	t.Helper()
 	engine := New(loadKB(t), "../testdata/ruby-project")
 	r, err := engine.Run()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	return r
+}
 
-	// Language detection
+func TestRubyLanguage(t *testing.T) {
+	r := rubyReport(t)
 	if len(r.Languages) == 0 {
 		t.Fatal("expected at least one language")
 	}
 	if r.Languages[0].Name != "Ruby" {
 		t.Errorf("expected Ruby language, got %s", r.Languages[0].Name)
 	}
+}
 
-	// Package manager
+func TestRubyPackageManager(t *testing.T) {
+	r := rubyReport(t)
 	if len(r.PackageManagers) == 0 {
 		t.Fatal("expected at least one package manager")
 	}
@@ -50,14 +56,16 @@ func TestRubyProject(t *testing.T) {
 	if !found {
 		t.Error("expected Bundler package manager")
 	}
+}
 
-	// Test framework
+func TestRubyTools(t *testing.T) {
+	r := rubyReport(t)
 	assertToolDetected(t, r, "test", "RSpec")
-
-	// Linter
 	assertToolDetected(t, r, "lint", "RuboCop")
+}
 
-	// Scripts
+func TestRubyScripts(t *testing.T) {
+	r := rubyReport(t)
 	if len(r.Scripts) == 0 {
 		t.Error("expected scripts from Makefile")
 	}
@@ -70,8 +78,10 @@ func TestRubyProject(t *testing.T) {
 	if !foundTest {
 		t.Error("expected 'test' script from Makefile")
 	}
+}
 
-	// Resources
+func TestRubyResources(t *testing.T) {
+	r := rubyReport(t)
 	if r.Resources == nil || r.Resources.Readme == "" {
 		t.Error("expected README to be detected")
 	}
@@ -81,8 +91,10 @@ func TestRubyProject(t *testing.T) {
 	if r.Resources != nil && r.Resources.LicenseType != "MIT" {
 		t.Errorf("expected MIT license, got %s", r.Resources.LicenseType)
 	}
+}
 
-	// Platforms
+func TestRubyPlatforms(t *testing.T) {
+	r := rubyReport(t)
 	if r.Platforms == nil {
 		t.Fatal("expected platform info")
 	}
@@ -97,8 +109,10 @@ func TestRubyProject(t *testing.T) {
 	if len(r.Platforms.CIMatrixOS) == 0 {
 		t.Error("expected OS targets from CI matrix")
 	}
+}
 
-	// Layout
+func TestRubyLayout(t *testing.T) {
+	r := rubyReport(t)
 	if r.Layout == nil {
 		t.Fatal("expected layout info")
 	}

--- a/detect/filter.go
+++ b/detect/filter.go
@@ -9,17 +9,20 @@ import (
 	"github.com/git-pkgs/brief/kb"
 )
 
-// FilterByChangedFiles takes a full report and returns a new report containing
-// only detections relevant to the given set of changed files. A detection is
-// relevant if a changed file matches one of its config files, lockfile,
-// detection file patterns, or file extensions (for languages).
-func FilterByChangedFiles(r *brief.Report, knowledgeBase *kb.KnowledgeBase, changedFiles []string) *brief.Report {
+// filterContext holds precomputed data used by filter helpers.
+type filterContext struct {
+	changed         map[string]bool
+	changedExts     map[string]bool
+	manifestChanged bool
+	kb              *kb.KnowledgeBase
+}
+
+func newFilterContext(knowledgeBase *kb.KnowledgeBase, changedFiles []string) *filterContext {
 	changed := make(map[string]bool, len(changedFiles))
 	for _, f := range changedFiles {
 		changed[f] = true
 	}
 
-	// Collect extensions from changed files.
 	changedExts := make(map[string]bool)
 	for _, f := range changedFiles {
 		if ext := filepath.Ext(f); ext != "" {
@@ -27,7 +30,6 @@ func FilterByChangedFiles(r *brief.Report, knowledgeBase *kb.KnowledgeBase, chan
 		}
 	}
 
-	// Check if any manifest files changed (signals dependency changes).
 	manifestChanged := false
 	for _, mf := range knowledgeBase.ManifestFiles {
 		if changed[mf] {
@@ -35,6 +37,19 @@ func FilterByChangedFiles(r *brief.Report, knowledgeBase *kb.KnowledgeBase, chan
 			break
 		}
 	}
+
+	return &filterContext{
+		changed:         changed,
+		changedExts:     changedExts,
+		manifestChanged: manifestChanged,
+		kb:              knowledgeBase,
+	}
+}
+
+// FilterByChangedFiles takes a full report and returns a new report containing
+// only detections relevant to the given set of changed files.
+func FilterByChangedFiles(r *brief.Report, knowledgeBase *kb.KnowledgeBase, changedFiles []string) *brief.Report {
+	fc := newFilterContext(knowledgeBase, changedFiles)
 
 	filtered := &brief.Report{
 		Version:      r.Version,
@@ -47,179 +62,194 @@ func FilterByChangedFiles(r *brief.Report, knowledgeBase *kb.KnowledgeBase, chan
 		Stats:        r.Stats,
 	}
 
-	// Languages: keep if any changed file has a matching extension.
-	for _, lang := range r.Languages {
-		tool := knowledgeBase.ByName[lang.Name]
-		if tool == nil {
-			continue
-		}
-		if toolMatchesChangedFiles(tool, changed, changedExts) {
-			filtered.Languages = append(filtered.Languages, lang)
-		}
-	}
+	filtered.Languages = fc.filterDetections(r.Languages)
+	filtered.PackageManagers = fc.filterPackageManagers(r.PackageManagers)
+	filtered.Scripts = fc.filterScripts(r.Scripts)
+	fc.filterTools(r.Tools, filtered.Tools)
+	filtered.Style = fc.filterStyle(r.Style)
+	filtered.Resources = fc.filterResources(r.Resources, changedFiles)
+	filtered.Platforms = fc.filterPlatforms(r.Platforms, changedFiles)
 
-	// Package managers: keep if config/lockfile changed or manifests changed.
-	for _, pm := range r.PackageManagers {
-		tool := knowledgeBase.ByName[pm.Name]
-		if tool == nil {
-			continue
-		}
-		if toolMatchesChangedFiles(tool, changed, changedExts) || manifestChanged {
-			filtered.PackageManagers = append(filtered.PackageManagers, pm)
-		}
-	}
-
-	// Scripts: keep if the script source file changed.
-	scriptSourceFiles := make(map[string]bool)
-	for _, src := range knowledgeBase.ScriptSources {
-		scriptSourceFiles[src.Source.File] = true
-	}
-	for _, s := range r.Scripts {
-		// Find the source file for this script's source name.
-		for _, src := range knowledgeBase.ScriptSources {
-			if src.Source.Name == s.Source && changed[src.Source.File] {
-				filtered.Scripts = append(filtered.Scripts, s)
-				break
-			}
-		}
-	}
-
-	// Tools: keep if config files, detection files, or dependencies changed.
-	for cat, tools := range r.Tools {
-		for _, det := range tools {
-			tool := knowledgeBase.ByName[det.Name]
-			if tool == nil {
-				continue
-			}
-			keep := toolMatchesChangedFiles(tool, changed, changedExts)
-			// Also keep if this tool is dependency-detected and a manifest changed.
-			if !keep && manifestChanged && (len(tool.Detect.Dependencies) > 0 || len(tool.Detect.DevDependencies) > 0) {
-				keep = true
-			}
-			if keep {
-				filtered.Tools[cat] = append(filtered.Tools[cat], det)
-			}
-		}
-	}
-
-	// Style: keep if any style config file changed.
-	if r.Style != nil && knowledgeBase.StyleConfig != nil {
-		for _, cf := range knowledgeBase.StyleConfig.Style.ConfigFiles {
-			if changed[cf.File] {
-				filtered.Style = r.Style
-				break
-			}
-		}
-		// Also keep if source files changed (style could be re-inferred).
-		if filtered.Style == nil && r.Style.IndentSource == "inferred" {
-			for ext := range changedExts {
-				if slices.Contains(knowledgeBase.StyleConfig.Style.SampleExts, ext) {
-					filtered.Style = r.Style
-					break
-				}
-			}
-		}
-	}
-
-	// Resources: keep if the resource file itself changed.
-	if r.Resources != nil {
-		res := &brief.ResourceInfo{}
-		found := false
-		for _, f := range changedFiles {
-			base := filepath.Base(f)
-			baseLower := strings.ToLower(base)
-			if r.Resources.Readme != "" && strings.ToLower(r.Resources.Readme) == baseLower {
-				res.Readme = r.Resources.Readme
-				found = true
-			}
-			if r.Resources.Contributing != "" && strings.ToLower(r.Resources.Contributing) == baseLower {
-				res.Contributing = r.Resources.Contributing
-				found = true
-			}
-			if r.Resources.Changelog != "" && strings.ToLower(r.Resources.Changelog) == baseLower {
-				res.Changelog = r.Resources.Changelog
-				found = true
-			}
-			if r.Resources.License != "" && strings.ToLower(r.Resources.License) == baseLower {
-				res.License = r.Resources.License
-				res.LicenseType = r.Resources.LicenseType
-				found = true
-			}
-			if r.Resources.Security != "" && strings.ToLower(r.Resources.Security) == baseLower {
-				res.Security = r.Resources.Security
-				found = true
-			}
-		}
-		if found {
-			filtered.Resources = res
-		}
-	}
-
-	// Platforms: keep runtime version files that changed, CI config that changed.
-	if r.Platforms != nil {
-		plat := &brief.PlatformInfo{
-			RuntimeVersionFiles: make(map[string]string),
-			CIMatrixVersions:    make(map[string][]string),
-		}
-		found := false
-		for file, version := range r.Platforms.RuntimeVersionFiles {
-			if changed[file] {
-				plat.RuntimeVersionFiles[file] = version
-				found = true
-			}
-		}
-		// CI matrix: keep if any workflow file changed.
-		for _, f := range changedFiles {
-			if strings.HasPrefix(f, ".github/workflows/") {
-				plat.CIMatrixVersions = r.Platforms.CIMatrixVersions
-				plat.CIMatrixOS = r.Platforms.CIMatrixOS
-				found = true
-				break
-			}
-		}
-		if found {
-			filtered.Platforms = plat
-		}
-	}
-
-	// Dependencies: keep if manifests changed.
-	if manifestChanged {
+	if fc.manifestChanged {
 		filtered.Dependencies = r.Dependencies
 	}
 
 	return filtered
 }
 
+func (fc *filterContext) filterDetections(dets []brief.Detection) []brief.Detection {
+	var result []brief.Detection
+	for _, det := range dets {
+		tool := fc.kb.ByName[det.Name]
+		if tool != nil && toolMatchesChangedFiles(tool, fc.changed, fc.changedExts) {
+			result = append(result, det)
+		}
+	}
+	return result
+}
+
+func (fc *filterContext) filterPackageManagers(managers []brief.Detection) []brief.Detection {
+	var result []brief.Detection
+	for _, pm := range managers {
+		tool := fc.kb.ByName[pm.Name]
+		if tool == nil {
+			continue
+		}
+		if toolMatchesChangedFiles(tool, fc.changed, fc.changedExts) || fc.manifestChanged {
+			result = append(result, pm)
+		}
+	}
+	return result
+}
+
+func (fc *filterContext) filterScripts(scripts []brief.Script) []brief.Script {
+	var result []brief.Script
+	for _, s := range scripts {
+		for _, src := range fc.kb.ScriptSources {
+			if src.Source.Name == s.Source && fc.changed[src.Source.File] {
+				result = append(result, s)
+				break
+			}
+		}
+	}
+	return result
+}
+
+func (fc *filterContext) filterTools(tools map[string][]brief.Detection, out map[string][]brief.Detection) {
+	for cat, dets := range tools {
+		for _, det := range dets {
+			tool := fc.kb.ByName[det.Name]
+			if tool == nil {
+				continue
+			}
+			keep := toolMatchesChangedFiles(tool, fc.changed, fc.changedExts)
+			if !keep && fc.manifestChanged && (len(tool.Detect.Dependencies) > 0 || len(tool.Detect.DevDependencies) > 0) {
+				keep = true
+			}
+			if keep {
+				out[cat] = append(out[cat], det)
+			}
+		}
+	}
+}
+
+func (fc *filterContext) filterStyle(style *brief.StyleInfo) *brief.StyleInfo {
+	if style == nil || fc.kb.StyleConfig == nil {
+		return nil
+	}
+	for _, cf := range fc.kb.StyleConfig.Style.ConfigFiles {
+		if fc.changed[cf.File] {
+			return style
+		}
+	}
+	if style.IndentSource == "inferred" {
+		for ext := range fc.changedExts {
+			if slices.Contains(fc.kb.StyleConfig.Style.SampleExts, ext) {
+				return style
+			}
+		}
+	}
+	return nil
+}
+
+func (fc *filterContext) filterResources(res *brief.ResourceInfo, changedFiles []string) *brief.ResourceInfo {
+	if res == nil {
+		return nil
+	}
+	out := &brief.ResourceInfo{}
+	found := false
+	for _, f := range changedFiles {
+		baseLower := strings.ToLower(filepath.Base(f))
+		if res.Readme != "" && strings.ToLower(res.Readme) == baseLower {
+			out.Readme = res.Readme
+			found = true
+		}
+		if res.Contributing != "" && strings.ToLower(res.Contributing) == baseLower {
+			out.Contributing = res.Contributing
+			found = true
+		}
+		if res.Changelog != "" && strings.ToLower(res.Changelog) == baseLower {
+			out.Changelog = res.Changelog
+			found = true
+		}
+		if res.License != "" && strings.ToLower(res.License) == baseLower {
+			out.License = res.License
+			out.LicenseType = res.LicenseType
+			found = true
+		}
+		if res.Security != "" && strings.ToLower(res.Security) == baseLower {
+			out.Security = res.Security
+			found = true
+		}
+	}
+	if !found {
+		return nil
+	}
+	return out
+}
+
+func (fc *filterContext) filterPlatforms(plat *brief.PlatformInfo, changedFiles []string) *brief.PlatformInfo {
+	if plat == nil {
+		return nil
+	}
+	out := &brief.PlatformInfo{
+		RuntimeVersionFiles: make(map[string]string),
+		CIMatrixVersions:    make(map[string][]string),
+	}
+	found := false
+	for file, version := range plat.RuntimeVersionFiles {
+		if fc.changed[file] {
+			out.RuntimeVersionFiles[file] = version
+			found = true
+		}
+	}
+	for _, f := range changedFiles {
+		if strings.HasPrefix(f, ".github/workflows/") {
+			out.CIMatrixVersions = plat.CIMatrixVersions
+			out.CIMatrixOS = plat.CIMatrixOS
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil
+	}
+	return out
+}
+
 // toolMatchesChangedFiles checks whether any changed file is relevant to a tool's
 // detection signals: config files, lockfile, detection file patterns, or
 // file_contains targets.
 func toolMatchesChangedFiles(tool *kb.ToolDef, changed map[string]bool, changedExts map[string]bool) bool {
-	// Check config files.
+	if matchesConfigFiles(tool, changed) {
+		return true
+	}
+	if matchesDetectionPatterns(tool, changed, changedExts) {
+		return true
+	}
+	return matchesContentTargets(tool, changed)
+}
+
+func matchesConfigFiles(tool *kb.ToolDef, changed map[string]bool) bool {
 	for _, cf := range tool.Config.Files {
 		if changed[cf] {
 			return true
 		}
 	}
+	return tool.Config.Lockfile != "" && changed[tool.Config.Lockfile]
+}
 
-	// Check lockfile.
-	if tool.Config.Lockfile != "" && changed[tool.Config.Lockfile] {
-		return true
-	}
-
-	// Check detection file patterns.
+func matchesDetectionPatterns(tool *kb.ToolDef, changed map[string]bool, changedExts map[string]bool) bool {
 	for _, pattern := range tool.Detect.Files {
-		// Direct file match.
 		if changed[pattern] {
 			return true
 		}
-		// Extension-based pattern like "*.py" or "**/*.py".
 		if idx := strings.LastIndex(pattern, "*."); idx >= 0 {
-			ext := pattern[idx+1:] // ".py"
+			ext := pattern[idx+1:]
 			if changedExts[ext] {
 				return true
 			}
 		}
-		// Directory pattern like "src/" - check if any changed file is under it.
 		if strings.HasSuffix(pattern, "/") {
 			for f := range changed {
 				if strings.HasPrefix(f, pattern) {
@@ -227,7 +257,6 @@ func toolMatchesChangedFiles(tool *kb.ToolDef, changed map[string]bool, changedE
 				}
 			}
 		}
-		// Glob match individual changed files.
 		if strings.ContainsAny(pattern, "*?[") {
 			for f := range changed {
 				if matched, _ := filepath.Match(pattern, f); matched {
@@ -236,20 +265,19 @@ func toolMatchesChangedFiles(tool *kb.ToolDef, changed map[string]bool, changedE
 			}
 		}
 	}
+	return false
+}
 
-	// Check file_contains targets.
+func matchesContentTargets(tool *kb.ToolDef, changed map[string]bool) bool {
 	for file := range tool.Detect.FileContains {
 		if changed[file] {
 			return true
 		}
 	}
-
-	// Check key_exists targets.
 	for file := range tool.Detect.KeyExists {
 		if changed[file] {
 			return true
 		}
 	}
-
 	return false
 }

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	forges "github.com/git-pkgs/forge"
@@ -56,8 +55,9 @@ func Resolve(ctx context.Context, source string, opts Options) (*Source, error) 
 
 // parseRegistryShorthand checks if the source looks like "npm:lodash" or "gem:rails".
 func parseRegistryShorthand(source string) (ecosystem, name string, ok bool) {
-	parts := strings.SplitN(source, ":", 2)
-	if len(parts) != 2 {
+	const splitParts = 2
+	parts := strings.SplitN(source, ":", splitParts)
+	if len(parts) != splitParts {
 		return "", "", false
 	}
 	prefix := parts[0]
@@ -157,9 +157,4 @@ func cloneURL(ctx context.Context, url, name string, opts Options) (*Source, err
 	}
 
 	return &Source{Dir: dir, Cleanup: cleanup, Origin: url}, nil
-}
-
-// TempDir returns the path to the temporary directory, useful for --keep output.
-func (s *Source) TempDir() string {
-	return filepath.Clean(s.Dir)
 }

--- a/report/report.go
+++ b/report/report.go
@@ -32,6 +32,33 @@ func JSON(w io.Writer, r *brief.Report) error {
 	return enc.Encode(r)
 }
 
+const maxDisplayItems = 20 // max items to show before truncating
+
+// categoryOrder defines the stable display order for tool categories.
+var categoryOrder = []string{"test", "lint", "format", "typecheck", "docs", "build", "codegen", "database", "security", "ci", "container", "infrastructure", "monorepo", "environment", "i18n", "release", "coverage", "dependency_bot"}
+
+// categoryLabels maps category keys to human-readable labels.
+var categoryLabels = map[string]string{
+	"test":           "Test",
+	"lint":           "Lint",
+	"format":         "Format",
+	"typecheck":      "Typecheck",
+	"docs":           "Docs",
+	"build":          "Build",
+	"codegen":        "Codegen",
+	"database":       "Database",
+	"security":       "Security",
+	"ci":             "CI",
+	"container":      "Container",
+	"infrastructure": "Infra",
+	"monorepo":       "Monorepo",
+	"environment":    "Environment",
+	"i18n":           "i18n",
+	"release":        "Release",
+	"coverage":       "Coverage",
+	"dependency_bot": "Dep Updates",
+}
+
 // Human writes the report in human-readable format.
 func Human(w io.Writer, r *brief.Report, verbose bool) {
 	_, _ = fmt.Fprintf(w, "brief %s — %s\n", r.Version, sanitize(r.Path))
@@ -42,44 +69,57 @@ func Human(w io.Writer, r *brief.Report, verbose bool) {
 
 	_, _ = fmt.Fprintln(w)
 
-	// Commits (in diff mode only)
-	if len(r.DiffCommits) > 0 {
-		_, _ = fmt.Fprintf(w, "Commits:\n")
-		limit := min(len(r.DiffCommits), 20)
-		for _, c := range r.DiffCommits[:limit] {
-			_, _ = fmt.Fprintf(w, "  %s\n", sanitize(c))
-		}
-		if len(r.DiffCommits) > 20 {
-			_, _ = fmt.Fprintf(w, "  ... and %d more\n", len(r.DiffCommits)-20)
-		}
-		_, _ = fmt.Fprintln(w)
-	}
+	printTruncatedList(w, "Commits:", r.DiffCommits)
+	printTruncatedList(w, "Changed:", r.ChangedFiles)
+	printLanguages(w, r.Languages)
+	printPackageManagers(w, r.PackageManagers)
+	printDependencySummary(w, r.Dependencies)
+	printScripts(w, r.Scripts)
 
-	// Changed files (in diff mode only)
-	if len(r.ChangedFiles) > 0 {
-		_, _ = fmt.Fprintf(w, "Changed:\n")
-		limit := min(len(r.ChangedFiles), 20)
-		for _, f := range r.ChangedFiles[:limit] {
-			_, _ = fmt.Fprintf(w, "  %s\n", sanitize(f))
-		}
-		if len(r.ChangedFiles) > 20 {
-			_, _ = fmt.Fprintf(w, "  ... and %d more\n", len(r.ChangedFiles)-20)
-		}
-		_, _ = fmt.Fprintln(w)
-	}
+	_, _ = fmt.Fprintln(w)
 
-	// Languages
-	if len(r.Languages) > 0 {
-		names := detectionNames(r.Languages)
-		if len(names) == 1 {
-			_, _ = fmt.Fprintf(w, "Language:        %s\n", names[0])
-		} else {
-			_, _ = fmt.Fprintf(w, "Language:        %s (also: %s)\n", names[0], strings.Join(names[1:], ", "))
-		}
-	}
+	printTools(w, r.Tools, verbose)
+	printStyle(w, r.Style)
+	printLayout(w, r.Layout)
+	printPlatforms(w, r.Platforms)
+	printResources(w, r.Resources)
+	printGit(w, r.Git)
+	printLines(w, r.Lines)
+	printEnrichment(w, r.Enrichment)
 
-	// Package managers
-	for _, pm := range r.PackageManagers {
+	_, _ = fmt.Fprintf(w, "\n%.1fms  %d files checked  %d/%d tools matched\n",
+		r.Stats.DurationMS, r.Stats.FilesChecked, r.Stats.ToolsMatched, r.Stats.ToolsChecked)
+}
+
+func printTruncatedList(w io.Writer, header string, items []string) {
+	if len(items) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintf(w, "%s\n", header)
+	limit := min(len(items), maxDisplayItems)
+	for _, item := range items[:limit] {
+		_, _ = fmt.Fprintf(w, "  %s\n", sanitize(item))
+	}
+	if len(items) > maxDisplayItems {
+		_, _ = fmt.Fprintf(w, "  ... and %d more\n", len(items)-maxDisplayItems)
+	}
+	_, _ = fmt.Fprintln(w)
+}
+
+func printLanguages(w io.Writer, languages []brief.Detection) {
+	if len(languages) == 0 {
+		return
+	}
+	names := detectionNames(languages)
+	if len(names) == 1 {
+		_, _ = fmt.Fprintf(w, "Language:        %s\n", names[0])
+	} else {
+		_, _ = fmt.Fprintf(w, "Language:        %s (also: %s)\n", names[0], strings.Join(names[1:], ", "))
+	}
+}
+
+func printPackageManagers(w io.Writer, managers []brief.Detection) {
+	for _, pm := range managers {
 		line := pm.Name
 		if pm.Command != nil {
 			line += " (" + pm.Command.Run + ")"
@@ -89,127 +129,86 @@ func Human(w io.Writer, r *brief.Report, verbose bool) {
 			_, _ = fmt.Fprintf(w, "                 Lockfile: %s\n", pm.Lockfile)
 		}
 	}
+}
 
-	// Dependencies (exclude CI actions from counts)
-	if len(r.Dependencies) > 0 {
-		directRuntime, directDev, totalRuntime, totalDev := 0, 0, 0, 0
-		for _, d := range r.Dependencies {
-			if strings.HasPrefix(d.PURL, "pkg:githubactions/") || strings.HasPrefix(d.PURL, "pkg:docker/") {
-				continue
-			}
-			isDev := d.Scope == "development" || d.Scope == "test" || d.Scope == "build"
-			if isDev {
-				totalDev++
-				if d.Direct {
-					directDev++
-				}
-			} else {
-				totalRuntime++
-				if d.Direct {
-					directRuntime++
-				}
-			}
+func printDependencySummary(w io.Writer, deps []brief.DepInfo) {
+	if len(deps) == 0 {
+		return
+	}
+	directRuntime, directDev, totalRuntime, totalDev := 0, 0, 0, 0
+	for _, d := range deps {
+		if strings.HasPrefix(d.PURL, "pkg:githubactions/") || strings.HasPrefix(d.PURL, "pkg:docker/") {
+			continue
 		}
-		var parts []string
-		if directRuntime > 0 {
-			s := fmt.Sprintf("%d runtime", directRuntime)
-			if transitive := totalRuntime - directRuntime; transitive > 0 {
-				s += fmt.Sprintf(" (%d total)", totalRuntime)
+		isDev := d.Scope == brief.ScopeDevelopment || d.Scope == brief.ScopeTest || d.Scope == brief.ScopeBuild
+		if isDev {
+			totalDev++
+			if d.Direct {
+				directDev++
 			}
-			parts = append(parts, s)
-		}
-		if directDev > 0 {
-			s := fmt.Sprintf("%d dev", directDev)
-			if transitive := totalDev - directDev; transitive > 0 {
-				s += fmt.Sprintf(" (%d total)", totalDev)
+		} else {
+			totalRuntime++
+			if d.Direct {
+				directRuntime++
 			}
-			parts = append(parts, s)
-		}
-		if len(parts) > 0 {
-			_, _ = fmt.Fprintf(w, "                 %s\n", strings.Join(parts, ", "))
 		}
 	}
-
-	// Scripts
-	if len(r.Scripts) > 0 {
-		_, _ = fmt.Fprintln(w)
-		source := r.Scripts[0].Source
-		_, _ = fmt.Fprintf(w, "Scripts (%s):\n", source)
-		for _, s := range r.Scripts {
-			if s.Source != source {
-				_, _ = fmt.Fprintf(w, "\nScripts (%s):\n", s.Source)
-				source = s.Source
-			}
-			_, _ = fmt.Fprintf(w, "  %-8s %s\n", sanitize(s.Name)+":", sanitize(s.Run))
+	var parts []string
+	if directRuntime > 0 {
+		s := fmt.Sprintf("%d runtime", directRuntime)
+		if transitive := totalRuntime - directRuntime; transitive > 0 {
+			s += fmt.Sprintf(" (%d total)", totalRuntime)
 		}
+		parts = append(parts, s)
 	}
+	if directDev > 0 {
+		s := fmt.Sprintf("%d dev", directDev)
+		if transitive := totalDev - directDev; transitive > 0 {
+			s += fmt.Sprintf(" (%d total)", totalDev)
+		}
+		parts = append(parts, s)
+	}
+	if len(parts) > 0 {
+		_, _ = fmt.Fprintf(w, "                 %s\n", strings.Join(parts, ", "))
+	}
+}
 
+func printScripts(w io.Writer, scripts []brief.Script) {
+	if len(scripts) == 0 {
+		return
+	}
 	_, _ = fmt.Fprintln(w)
-
-	// Tool categories in a stable order
-	categoryOrder := []string{"test", "lint", "format", "typecheck", "docs", "build", "codegen", "database", "security", "ci", "container", "infrastructure", "monorepo", "environment", "i18n", "release", "coverage", "dependency_bot"}
-	categoryLabels := map[string]string{
-		"test":           "Test",
-		"lint":           "Lint",
-		"format":         "Format",
-		"typecheck":      "Typecheck",
-		"docs":           "Docs",
-		"build":          "Build",
-		"codegen":        "Codegen",
-		"database":       "Database",
-		"security":       "Security",
-		"ci":             "CI",
-		"container":      "Container",
-		"infrastructure": "Infra",
-		"monorepo":       "Monorepo",
-		"environment":    "Environment",
-		"i18n":           "i18n",
-		"release":        "Release",
-		"coverage":       "Coverage",
-		"dependency_bot": "Dep Updates",
+	source := scripts[0].Source
+	_, _ = fmt.Fprintf(w, "Scripts (%s):\n", source)
+	for _, s := range scripts {
+		if s.Source != source {
+			_, _ = fmt.Fprintf(w, "\nScripts (%s):\n", s.Source)
+			source = s.Source
+		}
+		_, _ = fmt.Fprintf(w, "  %-8s %s\n", sanitize(s.Name)+":", sanitize(s.Run))
 	}
+}
 
+func printTools(w io.Writer, tools map[string][]brief.Detection, verbose bool) {
 	for _, cat := range categoryOrder {
 		label := categoryLabels[cat]
 		if label == "" {
 			label = cat
 		}
-		tools, ok := r.Tools[cat]
+		dets, ok := tools[cat]
 		if !ok {
 			continue
 		}
-		for i, t := range tools {
-			prefix := label + ":"
-			if i > 0 {
-				prefix = ""
-			}
-			line := t.Name
-			if t.Command != nil {
-				line += " (" + sanitize(t.Command.Run) + ")"
-			}
-			if len(t.ConfigFiles) > 0 {
-				line += "  [" + sanitize(strings.Join(t.ConfigFiles, ", ")) + "]"
-			}
-			_, _ = fmt.Fprintf(w, "%-13s%s\n", prefix, line)
-
-			if verbose {
-				if t.Homepage != "" {
-					_, _ = fmt.Fprintf(w, "              homepage: %s\n", t.Homepage)
-				}
-				if t.Docs != "" {
-					_, _ = fmt.Fprintf(w, "              docs:     %s\n", t.Docs)
-				}
-			}
-		}
+		printToolCategory(w, label, dets, verbose)
 	}
 
 	// Print any categories not in the fixed order
-	for cat, tools := range r.Tools {
+	for cat, dets := range tools {
 		if categoryLabels[cat] != "" {
 			continue
 		}
 		_, _ = fmt.Fprintln(w)
-		for _, t := range tools {
+		for _, t := range dets {
 			line := t.Name
 			if t.Command != nil {
 				line += " (" + t.Command.Run + ")"
@@ -217,148 +216,179 @@ func Human(w io.Writer, r *brief.Report, verbose bool) {
 			_, _ = fmt.Fprintf(w, "%-13s%s\n", cat+":", line)
 		}
 	}
+}
 
-	// Style
-	if r.Style != nil {
+func printToolCategory(w io.Writer, label string, tools []brief.Detection, verbose bool) {
+	for i, t := range tools {
+		prefix := label + ":"
+		if i > 0 {
+			prefix = ""
+		}
+		line := t.Name
+		if t.Command != nil {
+			line += " (" + sanitize(t.Command.Run) + ")"
+		}
+		if len(t.ConfigFiles) > 0 {
+			line += "  [" + sanitize(strings.Join(t.ConfigFiles, ", ")) + "]"
+		}
+		_, _ = fmt.Fprintf(w, "%-13s%s\n", prefix, line)
+
+		if verbose {
+			if t.Homepage != "" {
+				_, _ = fmt.Fprintf(w, "              homepage: %s\n", t.Homepage)
+			}
+			if t.Docs != "" {
+				_, _ = fmt.Fprintf(w, "              docs:     %s\n", t.Docs)
+			}
+		}
+	}
+}
+
+func printStyle(w io.Writer, style *brief.StyleInfo) {
+	if style == nil {
+		return
+	}
+	_, _ = fmt.Fprintln(w)
+	var parts []string
+	if style.Indentation != "" {
+		s := style.Indentation
+		if style.IndentSource != "" {
+			s += " (" + style.IndentSource + ")"
+		}
+		parts = append(parts, s)
+	}
+	if style.LineEnding != "" {
+		parts = append(parts, style.LineEnding)
+	}
+	if style.TrailingNewline != nil {
+		if *style.TrailingNewline {
+			parts = append(parts, "trailing newline")
+		} else {
+			parts = append(parts, "no trailing newline")
+		}
+	}
+	if len(parts) > 0 {
+		_, _ = fmt.Fprintf(w, "Style:       %s\n", strings.Join(parts, "  "))
+	}
+}
+
+func printLayout(w io.Writer, layout *brief.LayoutInfo) {
+	if layout == nil {
+		return
+	}
+	var parts []string
+	if len(layout.SourceDirs) > 0 {
+		parts = append(parts, strings.Join(layout.SourceDirs, "/ ")+"/ ")
+	}
+	if len(layout.TestDirs) > 0 {
+		parts = append(parts, strings.Join(layout.TestDirs, "/ ")+"/")
+	}
+	if len(parts) > 0 {
+		_, _ = fmt.Fprintf(w, "Layout:      %s\n", strings.Join(parts, " "))
+	}
+}
+
+func printPlatforms(w io.Writer, platforms *brief.PlatformInfo) {
+	if platforms == nil {
+		return
+	}
+	_, _ = fmt.Fprintln(w)
+	for name, versions := range platforms.CIMatrixVersions {
+		_, _ = fmt.Fprintf(w, "Platforms:   %s %s (CI matrix)\n", name, strings.Join(versions, ", "))
+	}
+	for file, version := range platforms.RuntimeVersionFiles {
+		_, _ = fmt.Fprintf(w, "             %s: %s\n", sanitize(file), sanitize(version))
+	}
+	if len(platforms.CIMatrixOS) > 0 {
+		_, _ = fmt.Fprintf(w, "             OS: %s (CI matrix)\n", strings.Join(platforms.CIMatrixOS, ", "))
+	}
+}
+
+func printResources(w io.Writer, res *brief.ResourceInfo) {
+	if res == nil {
+		return
+	}
+	_, _ = fmt.Fprintln(w)
+	printResource(w, res.Readme)
+	printResource(w, res.Contributing)
+	printResource(w, res.Changelog)
+	if res.License != "" {
+		label := res.License
+		if res.LicenseType != "" {
+			label += " (" + res.LicenseType + ")"
+		}
+		_, _ = fmt.Fprintf(w, "Resources:   %s\n", label)
+	}
+	printResource(w, res.Security)
+}
+
+func printGit(w io.Writer, git *brief.GitInfo) {
+	if git == nil {
+		return
+	}
+	_, _ = fmt.Fprintln(w)
+	if git.Branch != "" {
+		_, _ = fmt.Fprintf(w, "Git:         branch %s", sanitize(git.Branch))
+		if git.DefaultBranch != "" && git.DefaultBranch != git.Branch {
+			_, _ = fmt.Fprintf(w, " (default: %s)", sanitize(git.DefaultBranch))
+		}
+		if git.CommitCount > 0 {
+			_, _ = fmt.Fprintf(w, "  %d commits", git.CommitCount)
+		}
 		_, _ = fmt.Fprintln(w)
-		parts := []string{}
-		if r.Style.Indentation != "" {
-			s := r.Style.Indentation
-			if r.Style.IndentSource != "" {
-				s += " (" + r.Style.IndentSource + ")"
-			}
-			parts = append(parts, s)
-		}
-		if r.Style.LineEnding != "" {
-			parts = append(parts, r.Style.LineEnding)
-		}
-		if r.Style.TrailingNewline != nil {
-			if *r.Style.TrailingNewline {
-				parts = append(parts, "trailing newline")
-			} else {
-				parts = append(parts, "no trailing newline")
-			}
-		}
-		if len(parts) > 0 {
-			_, _ = fmt.Fprintf(w, "Style:       %s\n", strings.Join(parts, "  "))
-		}
 	}
-
-	// Layout
-	if r.Layout != nil {
-		parts := []string{}
-		if len(r.Layout.SourceDirs) > 0 {
-			parts = append(parts, strings.Join(r.Layout.SourceDirs, "/ ")+"/ ")
-		}
-		if len(r.Layout.TestDirs) > 0 {
-			parts = append(parts, strings.Join(r.Layout.TestDirs, "/ ")+"/")
-		}
-		if len(parts) > 0 {
-			_, _ = fmt.Fprintf(w, "Layout:      %s\n", strings.Join(parts, " "))
-		}
+	for name, url := range git.Remotes {
+		_, _ = fmt.Fprintf(w, "             %s: %s\n", sanitize(name), sanitize(url))
 	}
+}
 
-	// Platforms
-	if r.Platforms != nil {
+func printLines(w io.Writer, lines *brief.LineCount) {
+	if lines == nil {
+		return
+	}
+	_, _ = fmt.Fprintf(w, "\nLines:       %d code  %d files (%s)\n",
+		lines.TotalLines, lines.TotalFiles, lines.Source)
+}
+
+func printEnrichment(w io.Writer, e *brief.EnrichmentInfo) {
+	if e == nil {
+		return
+	}
+	if e.Repo != nil && e.Repo.Scorecard > 0 {
+		_, _ = fmt.Fprintf(w, "\nScorecard:   %.1f/10 (%s)\n", e.Repo.Scorecard, e.Repo.ScorecardDate)
+	}
+	if len(e.RuntimeEOL) > 0 {
 		_, _ = fmt.Fprintln(w)
-		for name, versions := range r.Platforms.CIMatrixVersions {
-			_, _ = fmt.Fprintf(w, "Platforms:   %s %s (CI matrix)\n", name, strings.Join(versions, ", "))
-		}
-		for file, version := range r.Platforms.RuntimeVersionFiles {
-			_, _ = fmt.Fprintf(w, "             %s: %s\n", sanitize(file), sanitize(version))
-		}
-		if len(r.Platforms.CIMatrixOS) > 0 {
-			_, _ = fmt.Fprintf(w, "             OS: %s (CI matrix)\n", strings.Join(r.Platforms.CIMatrixOS, ", "))
+		for name, eol := range e.RuntimeEOL {
+			status := "supported"
+			if !eol.Supported {
+				status = "EOL"
+			}
+			if eol.LTS {
+				status += ", LTS"
+			}
+			line := name + ": " + status
+			if eol.Latest != "" {
+				line += " (latest: " + eol.Latest + ")"
+			}
+			_, _ = fmt.Fprintf(w, "Runtime:     %s\n", line)
 		}
 	}
-
-	// Resources
-	if r.Resources != nil {
-		_, _ = fmt.Fprintln(w)
-		res := r.Resources
-		printResource(w, res.Readme)
-		printResource(w, res.Contributing)
-		printResource(w, res.Changelog)
-		if res.License != "" {
-			label := res.License
-			if res.LicenseType != "" {
-				label += " (" + res.LicenseType + ")"
-			}
-			_, _ = fmt.Fprintf(w, "Resources:   %s\n", label)
+	for _, pkg := range e.Packages {
+		_, _ = fmt.Fprintf(w, "Published:   %s (%s)\n", pkg.Name, pkg.Ecosystem)
+		if pkg.LatestVersion != "" {
+			_, _ = fmt.Fprintf(w, "             latest: %s\n", pkg.LatestVersion)
 		}
-		printResource(w, res.Security)
-	}
-
-	// Git
-	if r.Git != nil {
-		_, _ = fmt.Fprintln(w)
-		if r.Git.Branch != "" {
-			_, _ = fmt.Fprintf(w, "Git:         branch %s", sanitize(r.Git.Branch))
-			if r.Git.DefaultBranch != "" && r.Git.DefaultBranch != r.Git.Branch {
-				_, _ = fmt.Fprintf(w, " (default: %s)", sanitize(r.Git.DefaultBranch))
-			}
-			if r.Git.CommitCount > 0 {
-				_, _ = fmt.Fprintf(w, "  %d commits", r.Git.CommitCount)
-			}
-			_, _ = fmt.Fprintln(w)
+		if pkg.Downloads > 0 {
+			_, _ = fmt.Fprintf(w, "             downloads: %d (%s)\n", pkg.Downloads, pkg.DownloadsPeriod)
 		}
-		for name, url := range r.Git.Remotes {
-			_, _ = fmt.Fprintf(w, "             %s: %s\n", sanitize(name), sanitize(url))
+		if pkg.DependentReposCount > 0 {
+			_, _ = fmt.Fprintf(w, "             dependents: %d repos, %d packages\n", pkg.DependentReposCount, pkg.DependentPackagesCount)
+		}
+		if pkg.RegistryURL != "" {
+			_, _ = fmt.Fprintf(w, "             registry: %s\n", pkg.RegistryURL)
 		}
 	}
-
-	// Lines
-	if r.Lines != nil {
-		_, _ = fmt.Fprintf(w, "\nLines:       %d code  %d files (%s)\n",
-			r.Lines.TotalLines, r.Lines.TotalFiles, r.Lines.Source)
-	}
-
-	// Enrichment
-	if r.Enrichment != nil {
-		e := r.Enrichment
-		if e.Repo != nil && e.Repo.Scorecard > 0 {
-			_, _ = fmt.Fprintf(w, "\nScorecard:   %.1f/10 (%s)\n", e.Repo.Scorecard, e.Repo.ScorecardDate)
-		}
-		if len(e.RuntimeEOL) > 0 {
-			_, _ = fmt.Fprintln(w)
-			for name, eol := range e.RuntimeEOL {
-				status := "supported"
-				if !eol.Supported {
-					status = "EOL"
-				}
-				if eol.LTS {
-					status += ", LTS"
-				}
-				line := name + ": " + status
-				if eol.Latest != "" {
-					line += " (latest: " + eol.Latest + ")"
-				}
-				_, _ = fmt.Fprintf(w, "Runtime:     %s\n", line)
-			}
-		}
-		if len(e.Packages) > 0 {
-			_, _ = fmt.Fprintln(w)
-			for _, pkg := range e.Packages {
-				_, _ = fmt.Fprintf(w, "Published:   %s (%s)\n", pkg.Name, pkg.Ecosystem)
-				if pkg.LatestVersion != "" {
-					_, _ = fmt.Fprintf(w, "             latest: %s\n", pkg.LatestVersion)
-				}
-				if pkg.Downloads > 0 {
-					_, _ = fmt.Fprintf(w, "             downloads: %d (%s)\n", pkg.Downloads, pkg.DownloadsPeriod)
-				}
-				if pkg.DependentReposCount > 0 {
-					_, _ = fmt.Fprintf(w, "             dependents: %d repos, %d packages\n", pkg.DependentReposCount, pkg.DependentPackagesCount)
-				}
-				if pkg.RegistryURL != "" {
-					_, _ = fmt.Fprintf(w, "             registry: %s\n", pkg.RegistryURL)
-				}
-			}
-		}
-	}
-
-	// Stats
-	_, _ = fmt.Fprintf(w, "\n%.1fms  %d files checked  %d/%d tools matched\n",
-		r.Stats.DurationMS, r.Stats.FilesChecked, r.Stats.ToolsMatched, r.Stats.ToolsChecked)
 }
 
 // MissingJSON writes the missing report as JSON.


### PR DESCRIPTION
Resolve all 30 lint issues from golangci-lint with gocritic, gocognit, gocyclo, maintidx, dupl, mnd, unparam, ireturn, goconst, and errcheck enabled. The suite now reports 0 issues.

- Extract scope string constants and magic numbers into named constants
- Fix exitAfterDefer by extracting run helpers that return exit codes
- Refactor Human() report formatter into per-section print helpers
- Refactor FilterByChangedFiles into filterContext with focused methods
- Extract parseCIWorkflow/extractJobMatrix from parseCIMatrices
- Extract styleCounts type and buildEcosystemSet/detectTools/linkScriptToTool from Run
- Split TestRubyProject into focused test functions
- Remove unused Source.TempDir method and detectPublishedPURLs parameter