### PR TITLE
Add markdown output format

### DIFF
--- a/cmd/brief/diff.go
+++ b/cmd/brief/diff.go
@@ -19,6 +19,7 @@ func cmdDiff(args []string) {
 	fs := flag.NewFlagSet("brief diff", flag.ExitOnError)
 	jsonFlag := fs.Bool("json", false, "Force JSON output")
 	humanFlag := fs.Bool("human", false, "Force human-readable output")
+	markdownFlag := fs.Bool("markdown", false, "Force markdown output")
 	verbose := fs.Bool("verbose", false, "Include breadcrumb/reference information")
 	category := fs.String("category", "", "Only report on specific category")
 	_ = fs.Parse(args)
@@ -100,14 +101,15 @@ func cmdDiff(args []string) {
 		r = filterCategory(r, *category)
 	}
 
-	useJSON := *jsonFlag || (!*humanFlag && !isTTY())
-
-	if useJSON {
+	switch {
+	case *markdownFlag:
+		report.Markdown(os.Stdout, r, *verbose)
+	case *jsonFlag || (!*humanFlag && !isTTY()):
 		if err := report.JSON(os.Stdout, r); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "error writing JSON: %v\n", err)
 			os.Exit(1)
 		}
-	} else {
+	default:
 		report.Human(os.Stdout, r, *verbose)
 	}
 }

--- a/cmd/brief/enrich.go
+++ b/cmd/brief/enrich.go
@@ -25,6 +25,7 @@ func cmdEnrich(args []string) {
 	fs := flag.NewFlagSet("brief enrich", flag.ExitOnError)
 	jsonFlag := fs.Bool("json", false, "Force JSON output")
 	humanFlag := fs.Bool("human", false, "Force human-readable output")
+	markdownFlag := fs.Bool("markdown", false, "Force markdown output")
 	verbose := fs.Bool("verbose", false, "Include breadcrumb/reference information")
 	keep := fs.Bool("keep", false, "Keep downloaded remote source")
 	depth := fs.Int("depth", -1, "Git clone depth (0 = full clone, default shallow)")
@@ -48,12 +49,12 @@ func cmdEnrich(args []string) {
 		os.Exit(1)
 	}
 
-	code := runEnrich(src.Dir, *scanDepth, *skip, *jsonFlag, *humanFlag, *verbose)
+	code := runEnrich(src.Dir, *scanDepth, *skip, *jsonFlag, *humanFlag, *markdownFlag, *verbose)
 	src.Cleanup()
 	os.Exit(code)
 }
 
-func runEnrich(dir string, scanDepth int, skip string, jsonFlag, humanFlag, verbose bool) int {
+func runEnrich(dir string, scanDepth int, skip string, jsonFlag, humanFlag, markdownFlag, verbose bool) int {
 	knowledgeBase, err := kb.Load(brief.KnowledgeFS)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "error loading knowledge base: %v\n", err)
@@ -74,13 +75,15 @@ func runEnrich(dir string, scanDepth int, skip string, jsonFlag, humanFlag, verb
 	ctx := context.Background()
 	r.Enrichment = enrich(ctx, r, dir)
 
-	useJSON := jsonFlag || (!humanFlag && !isTTY())
-	if useJSON {
+	switch {
+	case markdownFlag:
+		report.Markdown(os.Stdout, r, verbose)
+	case jsonFlag || (!humanFlag && !isTTY()):
 		if err := report.JSON(os.Stdout, r); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "error writing JSON: %v\n", err)
 			return 1
 		}
-	} else {
+	default:
 		report.Human(os.Stdout, r, verbose)
 	}
 	return 0

--- a/cmd/brief/main.go
+++ b/cmd/brief/main.go
@@ -49,6 +49,7 @@ func cmdScan(args []string) {
 	fs := flag.NewFlagSet("brief", flag.ExitOnError)
 	jsonFlag := fs.Bool("json", false, "Force JSON output")
 	humanFlag := fs.Bool("human", false, "Force human-readable output")
+	markdownFlag := fs.Bool("markdown", false, "Force markdown output")
 	verbose := fs.Bool("verbose", false, "Include breadcrumb/reference information")
 	category := fs.String("category", "", "Only report on specific category")
 	keep := fs.Bool("keep", false, "Keep downloaded remote source")
@@ -80,12 +81,12 @@ func cmdScan(args []string) {
 		os.Exit(1)
 	}
 
-	code := runScan(src.Dir, *scanDepth, *skip, *category, *jsonFlag, *humanFlag, *verbose)
+	code := runScan(src.Dir, *scanDepth, *skip, *category, *jsonFlag, *humanFlag, *markdownFlag, *verbose)
 	src.Cleanup()
 	os.Exit(code)
 }
 
-func runScan(dir string, scanDepth int, skip, category string, jsonFlag, humanFlag, verbose bool) int {
+func runScan(dir string, scanDepth int, skip, category string, jsonFlag, humanFlag, markdownFlag, verbose bool) int {
 	knowledgeBase, err := kb.Load(brief.KnowledgeFS)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "error loading knowledge base: %v\n", err)
@@ -107,14 +108,15 @@ func runScan(dir string, scanDepth int, skip, category string, jsonFlag, humanFl
 		r = filterCategory(r, category)
 	}
 
-	useJSON := jsonFlag || (!humanFlag && !isTTY())
-
-	if useJSON {
+	switch {
+	case markdownFlag:
+		report.Markdown(os.Stdout, r, verbose)
+	case jsonFlag || (!humanFlag && !isTTY()):
 		if err := report.JSON(os.Stdout, r); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "error writing JSON: %v\n", err)
 			return 1
 		}
-	} else {
+	default:
 		report.Human(os.Stdout, r, verbose)
 	}
 	return 0

--- a/cmd/brief/missing.go
+++ b/cmd/brief/missing.go
@@ -16,6 +16,7 @@ func cmdMissing(args []string) {
 	fs := flag.NewFlagSet("brief missing", flag.ExitOnError)
 	jsonFlag := fs.Bool("json", false, "Force JSON output")
 	humanFlag := fs.Bool("human", false, "Force human-readable output")
+	markdownFlag := fs.Bool("markdown", false, "Force markdown output")
 	scanDepth := fs.Int("scan-depth", 0, "Max directory depth for language detection (default 4)")
 	skip := fs.String("skip", "", "Additional directories to skip, comma-separated")
 	_ = fs.Parse(args)
@@ -44,14 +45,15 @@ func cmdMissing(args []string) {
 
 	mr := engine.Missing(r)
 
-	useJSON := *jsonFlag || (!*humanFlag && !isTTY())
-
-	if useJSON {
+	switch {
+	case *markdownFlag:
+		report.MissingMarkdown(os.Stdout, mr)
+	case *jsonFlag || (!*humanFlag && !isTTY()):
 		if err := report.MissingJSON(os.Stdout, mr); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "error writing JSON: %v\n", err)
 			os.Exit(1)
 		}
-	} else {
+	default:
 		report.MissingHuman(os.Stdout, mr)
 	}
 }

--- a/report/markdown.go
+++ b/report/markdown.go
@@ -1,0 +1,358 @@
+package report
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/git-pkgs/brief"
+)
+
+// Markdown writes the report in markdown format.
+func Markdown(w io.Writer, r *brief.Report, verbose bool) {
+	_, _ = fmt.Fprintf(w, "# brief %s — %s\n\n", r.Version, sanitize(r.Path))
+
+	if r.DiffRef != "" {
+		_, _ = fmt.Fprintf(w, "diff %s (%d files changed)\n\n", r.DiffRef, len(r.ChangedFiles))
+	}
+
+	mdTruncatedList(w, "Commits", r.DiffCommits)
+	mdTruncatedList(w, "Changed", r.ChangedFiles)
+	mdLanguages(w, r.Languages)
+	mdPackageManagers(w, r.PackageManagers)
+	mdDependencySummary(w, r.Dependencies)
+	mdScripts(w, r.Scripts)
+	mdTools(w, r.Tools, verbose)
+	mdStyle(w, r.Style)
+	mdLayout(w, r.Layout)
+	mdPlatforms(w, r.Platforms)
+	mdResources(w, r.Resources)
+	mdGit(w, r.Git)
+	mdLines(w, r.Lines)
+	mdEnrichment(w, r.Enrichment)
+
+	_, _ = fmt.Fprintf(w, "---\n\n%.1fms | %d files checked | %d/%d tools matched\n",
+		r.Stats.DurationMS, r.Stats.FilesChecked, r.Stats.ToolsMatched, r.Stats.ToolsChecked)
+}
+
+func mdTruncatedList(w io.Writer, header string, items []string) {
+	if len(items) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintf(w, "**%s:**\n\n", header)
+	limit := min(len(items), maxDisplayItems)
+	for _, item := range items[:limit] {
+		_, _ = fmt.Fprintf(w, "- %s\n", sanitize(item))
+	}
+	if len(items) > maxDisplayItems {
+		_, _ = fmt.Fprintf(w, "- ... and %d more\n", len(items)-maxDisplayItems)
+	}
+	_, _ = fmt.Fprintln(w)
+}
+
+func mdLanguages(w io.Writer, languages []brief.Detection) {
+	if len(languages) == 0 {
+		return
+	}
+	names := detectionNames(languages)
+	if len(names) == 1 {
+		_, _ = fmt.Fprintf(w, "**Language:** %s\n", names[0])
+	} else {
+		_, _ = fmt.Fprintf(w, "**Language:** %s (also: %s)\n", names[0], strings.Join(names[1:], ", "))
+	}
+}
+
+func mdPackageManagers(w io.Writer, managers []brief.Detection) {
+	for _, pm := range managers {
+		line := pm.Name
+		if pm.Command != nil {
+			line += " (`" + pm.Command.Run + "`)"
+		}
+		_, _ = fmt.Fprintf(w, "**Package Manager:** %s\n", line)
+		if pm.Lockfile != "" {
+			_, _ = fmt.Fprintf(w, "Lockfile: %s\n", pm.Lockfile)
+		}
+	}
+}
+
+func mdDependencySummary(w io.Writer, deps []brief.DepInfo) {
+	if s := depSummary(deps); s != "" {
+		_, _ = fmt.Fprintf(w, "Dependencies: %s\n", s)
+	}
+}
+
+func mdScripts(w io.Writer, scripts []brief.Script) {
+	if len(scripts) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintln(w)
+	source := scripts[0].Source
+	_, _ = fmt.Fprintf(w, "## Scripts (%s)\n\n", source)
+	_, _ = fmt.Fprintln(w, "| Name | Command |")
+	_, _ = fmt.Fprintln(w, "|------|---------|")
+	for _, s := range scripts {
+		if s.Source != source {
+			_, _ = fmt.Fprintf(w, "\n## Scripts (%s)\n\n", s.Source)
+			_, _ = fmt.Fprintln(w, "| Name | Command |")
+			_, _ = fmt.Fprintln(w, "|------|---------|")
+			source = s.Source
+		}
+		_, _ = fmt.Fprintf(w, "| %s | `%s` |\n", sanitize(s.Name), sanitize(s.Run))
+	}
+	_, _ = fmt.Fprintln(w)
+}
+
+func mdTools(w io.Writer, tools map[string][]brief.Detection, verbose bool) {
+	if !hasAnyTools(tools) {
+		return
+	}
+
+	_, _ = fmt.Fprintf(w, "\n## Tools\n\n")
+	_, _ = fmt.Fprintln(w, "| Category | Tool | Command | Config |")
+	_, _ = fmt.Fprintln(w, "|----------|------|---------|--------|")
+
+	for _, cat := range categoryOrder {
+		label := categoryLabels[cat]
+		if label == "" {
+			label = cat
+		}
+		dets, ok := tools[cat]
+		if !ok {
+			continue
+		}
+		mdToolRows(w, label, dets)
+	}
+
+	// Print any categories not in the fixed order
+	for cat, dets := range tools {
+		if categoryLabels[cat] != "" {
+			continue
+		}
+		mdToolRows(w, cat, dets)
+	}
+
+	if verbose {
+		mdToolLinks(w, tools)
+	}
+
+	_, _ = fmt.Fprintln(w)
+}
+
+func hasAnyTools(tools map[string][]brief.Detection) bool {
+	for _, cat := range categoryOrder {
+		if _, ok := tools[cat]; ok {
+			return true
+		}
+	}
+	for cat := range tools {
+		if categoryLabels[cat] == "" {
+			return true
+		}
+	}
+	return false
+}
+
+func mdToolRows(w io.Writer, label string, dets []brief.Detection) {
+	for _, t := range dets {
+		cmd := ""
+		if t.Command != nil {
+			cmd = "`" + sanitize(t.Command.Run) + "`"
+		}
+		config := ""
+		if len(t.ConfigFiles) > 0 {
+			config = sanitize(strings.Join(t.ConfigFiles, ", "))
+		}
+		_, _ = fmt.Fprintf(w, "| %s | %s | %s | %s |\n", label, t.Name, cmd, config)
+	}
+}
+
+func mdToolLinks(w io.Writer, tools map[string][]brief.Detection) {
+	_, _ = fmt.Fprintln(w)
+	for _, cat := range categoryOrder {
+		dets, ok := tools[cat]
+		if !ok {
+			continue
+		}
+		for _, t := range dets {
+			if t.Homepage == "" && t.Docs == "" {
+				continue
+			}
+			_, _ = fmt.Fprintf(w, "**%s:**", t.Name)
+			if t.Homepage != "" {
+				_, _ = fmt.Fprintf(w, " [homepage](%s)", t.Homepage)
+			}
+			if t.Docs != "" {
+				_, _ = fmt.Fprintf(w, " [docs](%s)", t.Docs)
+			}
+			_, _ = fmt.Fprintln(w)
+		}
+	}
+}
+
+func mdStyle(w io.Writer, style *brief.StyleInfo) {
+	if style == nil {
+		return
+	}
+	var parts []string
+	if style.Indentation != "" {
+		s := style.Indentation
+		if style.IndentSource != "" {
+			s += " (" + style.IndentSource + ")"
+		}
+		parts = append(parts, s)
+	}
+	if style.LineEnding != "" {
+		parts = append(parts, style.LineEnding)
+	}
+	if style.TrailingNewline != nil {
+		if *style.TrailingNewline {
+			parts = append(parts, "trailing newline")
+		} else {
+			parts = append(parts, "no trailing newline")
+		}
+	}
+	if len(parts) > 0 {
+		_, _ = fmt.Fprintf(w, "**Style:** %s\n", strings.Join(parts, " | "))
+	}
+}
+
+func mdLayout(w io.Writer, layout *brief.LayoutInfo) {
+	if layout == nil {
+		return
+	}
+	var parts []string
+	if len(layout.SourceDirs) > 0 {
+		parts = append(parts, "source: "+strings.Join(layout.SourceDirs, "/, ")+"/")
+	}
+	if len(layout.TestDirs) > 0 {
+		parts = append(parts, "test: "+strings.Join(layout.TestDirs, "/, ")+"/")
+	}
+	if len(parts) > 0 {
+		_, _ = fmt.Fprintf(w, "**Layout:** %s\n", strings.Join(parts, " | "))
+	}
+}
+
+func mdPlatforms(w io.Writer, platforms *brief.PlatformInfo) {
+	if platforms == nil {
+		return
+	}
+	_, _ = fmt.Fprintln(w)
+	for name, versions := range platforms.CIMatrixVersions {
+		_, _ = fmt.Fprintf(w, "**Platforms:** %s %s (CI matrix)\n", name, strings.Join(versions, ", "))
+	}
+	for file, version := range platforms.RuntimeVersionFiles {
+		_, _ = fmt.Fprintf(w, "- %s: %s\n", sanitize(file), sanitize(version))
+	}
+	if len(platforms.CIMatrixOS) > 0 {
+		_, _ = fmt.Fprintf(w, "- OS: %s (CI matrix)\n", strings.Join(platforms.CIMatrixOS, ", "))
+	}
+}
+
+func mdResources(w io.Writer, res *brief.ResourceInfo) {
+	if res == nil {
+		return
+	}
+	hasAny := res.Readme != "" || res.Contributing != "" || res.Changelog != "" || res.License != "" || res.Security != ""
+	if !hasAny {
+		return
+	}
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, "**Resources:**")
+	if res.Readme != "" {
+		_, _ = fmt.Fprintf(w, "- %s\n", res.Readme)
+	}
+	if res.Contributing != "" {
+		_, _ = fmt.Fprintf(w, "- %s\n", res.Contributing)
+	}
+	if res.Changelog != "" {
+		_, _ = fmt.Fprintf(w, "- %s\n", res.Changelog)
+	}
+	if res.License != "" {
+		label := res.License
+		if res.LicenseType != "" {
+			label += " (" + res.LicenseType + ")"
+		}
+		_, _ = fmt.Fprintf(w, "- %s\n", label)
+	}
+	if res.Security != "" {
+		_, _ = fmt.Fprintf(w, "- %s\n", res.Security)
+	}
+}
+
+func mdGit(w io.Writer, git *brief.GitInfo) {
+	if git == nil {
+		return
+	}
+	_, _ = fmt.Fprintln(w)
+	if git.Branch != "" {
+		_, _ = fmt.Fprintf(w, "**Git:** branch `%s`", sanitize(git.Branch))
+		if git.DefaultBranch != "" && git.DefaultBranch != git.Branch {
+			_, _ = fmt.Fprintf(w, " (default: `%s`)", sanitize(git.DefaultBranch))
+		}
+		if git.CommitCount > 0 {
+			_, _ = fmt.Fprintf(w, " — %d commits", git.CommitCount)
+		}
+		_, _ = fmt.Fprintln(w)
+	}
+	for name, url := range git.Remotes {
+		_, _ = fmt.Fprintf(w, "- %s: %s\n", sanitize(name), sanitize(url))
+	}
+}
+
+func mdLines(w io.Writer, lines *brief.LineCount) {
+	if lines == nil {
+		return
+	}
+	_, _ = fmt.Fprintf(w, "\n**Lines:** %d code, %d files (%s)\n",
+		lines.TotalLines, lines.TotalFiles, lines.Source)
+}
+
+func mdEnrichment(w io.Writer, e *brief.EnrichmentInfo) {
+	if e == nil {
+		return
+	}
+	if e.Repo != nil && e.Repo.Scorecard > 0 {
+		_, _ = fmt.Fprintf(w, "\n**Scorecard:** %.1f/10 (%s)\n", e.Repo.Scorecard, e.Repo.ScorecardDate)
+	}
+	if len(e.RuntimeEOL) > 0 {
+		_, _ = fmt.Fprintln(w)
+		for name, eol := range e.RuntimeEOL {
+			_, _ = fmt.Fprintf(w, "**Runtime:** %s\n", enrichmentRuntimeLine(name, eol))
+		}
+	}
+	for _, pkg := range e.Packages {
+		_, _ = fmt.Fprintf(w, "\n**Published:** %s (%s)\n", pkg.Name, pkg.Ecosystem)
+		for _, line := range packageDetailLines(pkg) {
+			_, _ = fmt.Fprintf(w, "- %s\n", line)
+		}
+	}
+}
+
+// MissingMarkdown writes the missing report in markdown format.
+func MissingMarkdown(w io.Writer, r *brief.MissingReport) {
+	if len(r.Missing) == 0 {
+		_, _ = fmt.Fprintln(w, "No missing recommended tooling detected.")
+		return
+	}
+
+	_, _ = fmt.Fprintf(w, "**Detected:** %s\n\n", strings.Join(r.Ecosystems, ", "))
+	_, _ = fmt.Fprintf(w, "## Missing recommended tooling\n\n")
+	_, _ = fmt.Fprintln(w, "| Category | Suggested | Command | Docs |")
+	_, _ = fmt.Fprintln(w, "|----------|-----------|---------|------|")
+
+	for _, m := range r.Missing {
+		suggested := ""
+		if m.Suggested != "" {
+			suggested = m.Suggested
+		}
+		cmd := ""
+		if m.SuggestedCmd != "" {
+			cmd = "`" + sanitize(m.SuggestedCmd) + "`"
+		}
+		docs := ""
+		if m.Docs != "" {
+			docs = sanitize(m.Docs)
+		}
+		_, _ = fmt.Fprintf(w, "| %s | %s | %s | %s |\n", m.Label, suggested, cmd, docs)
+	}
+}

--- a/report/markdown_test.go
+++ b/report/markdown_test.go
@@ -1,0 +1,270 @@
+package report
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/git-pkgs/brief"
+)
+
+func TestMarkdownBasic(t *testing.T) {
+	r := &brief.Report{
+		Version: "dev",
+		Path:    "/tmp/test",
+		Languages: []brief.Detection{
+			{Name: "Go", Category: "language", Confidence: "high"},
+		},
+		PackageManagers: []brief.Detection{
+			{
+				Name:     "Go Modules",
+				Category: "package_manager",
+				Command:  &brief.Command{Run: "go mod download"},
+				Lockfile: "go.sum",
+			},
+		},
+		Tools: map[string][]brief.Detection{
+			"test": {
+				{Name: "go test", Command: &brief.Command{Run: "go test ./..."}},
+			},
+			"lint": {
+				{Name: "golangci-lint", Command: &brief.Command{Run: "golangci-lint run"}, ConfigFiles: []string{".golangci.yml"}},
+			},
+		},
+		Stats: brief.Stats{
+			DurationMS:   1.5,
+			FilesChecked: 10,
+			ToolsMatched: 2,
+			ToolsChecked: 50,
+		},
+	}
+
+	var buf bytes.Buffer
+	Markdown(&buf, r, false)
+	out := buf.String()
+
+	checks := []string{
+		"# brief dev",
+		"**Language:** Go",
+		"**Package Manager:** Go Modules (`go mod download`)",
+		"Lockfile: go.sum",
+		"## Tools",
+		"| Category | Tool | Command | Config |",
+		"| Test | go test | `go test ./...` |",
+		"| Lint | golangci-lint | `golangci-lint run` | .golangci.yml |",
+		"1.5ms | 10 files checked | 2/50 tools matched",
+	}
+	for _, want := range checks {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\ngot:\n%s", want, out)
+		}
+	}
+}
+
+func TestMarkdownVerbose(t *testing.T) {
+	r := &brief.Report{
+		Version: "dev",
+		Path:    "/tmp/test",
+		Tools: map[string][]brief.Detection{
+			"lint": {
+				{
+					Name:     "golangci-lint",
+					Homepage: "https://golangci-lint.run",
+					Docs:     "https://golangci-lint.run/usage/",
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	Markdown(&buf, r, true)
+	out := buf.String()
+
+	if !strings.Contains(out, "[homepage](https://golangci-lint.run)") {
+		t.Errorf("verbose output missing homepage link\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "[docs](https://golangci-lint.run/usage/)") {
+		t.Errorf("verbose output missing docs link\ngot:\n%s", out)
+	}
+}
+
+func TestMarkdownDiff(t *testing.T) {
+	r := &brief.Report{
+		Version:      "dev",
+		Path:         "/tmp/test",
+		DiffRef:      "main..HEAD",
+		ChangedFiles: []string{"foo.go", "bar.go"},
+		DiffCommits:  []string{"abc1234 fix stuff", "def5678 add thing"},
+	}
+
+	var buf bytes.Buffer
+	Markdown(&buf, r, false)
+	out := buf.String()
+
+	if !strings.Contains(out, "diff main..HEAD (2 files changed)") {
+		t.Errorf("missing diff ref line\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "- abc1234 fix stuff") {
+		t.Errorf("missing commit list\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "- foo.go") {
+		t.Errorf("missing changed files\ngot:\n%s", out)
+	}
+}
+
+func TestMarkdownStyle(t *testing.T) {
+	tn := true
+	r := &brief.Report{
+		Version: "dev",
+		Path:    "/tmp/test",
+		Style: &brief.StyleInfo{
+			Indentation:     "tabs",
+			IndentSource:    ".editorconfig",
+			LineEnding:      "LF",
+			TrailingNewline: &tn,
+		},
+	}
+
+	var buf bytes.Buffer
+	Markdown(&buf, r, false)
+	out := buf.String()
+
+	if !strings.Contains(out, "**Style:** tabs (.editorconfig) | LF | trailing newline") {
+		t.Errorf("style output wrong\ngot:\n%s", out)
+	}
+}
+
+func TestMarkdownResources(t *testing.T) {
+	r := &brief.Report{
+		Version: "dev",
+		Path:    "/tmp/test",
+		Resources: &brief.ResourceInfo{
+			Readme:  "README.md",
+			License: "LICENSE",
+		},
+	}
+
+	var buf bytes.Buffer
+	Markdown(&buf, r, false)
+	out := buf.String()
+
+	if !strings.Contains(out, "**Resources:**") {
+		t.Errorf("missing resources header\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "- README.md") {
+		t.Errorf("missing readme\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "- LICENSE") {
+		t.Errorf("missing license\ngot:\n%s", out)
+	}
+}
+
+func TestMarkdownGit(t *testing.T) {
+	r := &brief.Report{
+		Version: "dev",
+		Path:    "/tmp/test",
+		Git: &brief.GitInfo{
+			Branch:      "main",
+			CommitCount: 42,
+			Remotes:     map[string]string{"origin": "git@github.com:user/repo.git"},
+		},
+	}
+
+	var buf bytes.Buffer
+	Markdown(&buf, r, false)
+	out := buf.String()
+
+	if !strings.Contains(out, "**Git:** branch `main`") {
+		t.Errorf("missing git branch\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "42 commits") {
+		t.Errorf("missing commit count\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "- origin: git@github.com:user/repo.git") {
+		t.Errorf("missing remote\ngot:\n%s", out)
+	}
+}
+
+func TestMarkdownLines(t *testing.T) {
+	r := &brief.Report{
+		Version: "dev",
+		Path:    "/tmp/test",
+		Lines: &brief.LineCount{
+			TotalLines: 1000,
+			TotalFiles: 50,
+			Source:     "tokei",
+		},
+	}
+
+	var buf bytes.Buffer
+	Markdown(&buf, r, false)
+	out := buf.String()
+
+	if !strings.Contains(out, "**Lines:** 1000 code, 50 files (tokei)") {
+		t.Errorf("missing lines\ngot:\n%s", out)
+	}
+}
+
+func TestMarkdownScripts(t *testing.T) {
+	r := &brief.Report{
+		Version: "dev",
+		Path:    "/tmp/test",
+		Scripts: []brief.Script{
+			{Name: "test", Run: "jest", Source: "package.json"},
+			{Name: "build", Run: "tsc", Source: "package.json"},
+		},
+	}
+
+	var buf bytes.Buffer
+	Markdown(&buf, r, false)
+	out := buf.String()
+
+	if !strings.Contains(out, "## Scripts (package.json)") {
+		t.Errorf("missing scripts header\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "| test | `jest` |") {
+		t.Errorf("missing script row\ngot:\n%s", out)
+	}
+}
+
+func TestMissingMarkdown(t *testing.T) {
+	mr := &brief.MissingReport{
+		Ecosystems: []string{"Go"},
+		Missing: []brief.MissingCategory{
+			{
+				Label:        "Format",
+				Suggested:    "gofmt",
+				SuggestedCmd: "gofmt -w .",
+				Docs:         "https://go.dev/blog/gofmt",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	MissingMarkdown(&buf, mr)
+	out := buf.String()
+
+	checks := []string{
+		"**Detected:** Go",
+		"## Missing recommended tooling",
+		"| Category | Suggested | Command | Docs |",
+		"| Format | gofmt | `gofmt -w .` |",
+	}
+	for _, want := range checks {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\ngot:\n%s", want, out)
+		}
+	}
+}
+
+func TestMissingMarkdownEmpty(t *testing.T) {
+	mr := &brief.MissingReport{}
+
+	var buf bytes.Buffer
+	MissingMarkdown(&buf, mr)
+	out := buf.String()
+
+	if !strings.Contains(out, "No missing recommended tooling detected.") {
+		t.Errorf("expected empty message\ngot:\n%s", out)
+	}
+}

--- a/report/report.go
+++ b/report/report.go
@@ -132,44 +132,8 @@ func printPackageManagers(w io.Writer, managers []brief.Detection) {
 }
 
 func printDependencySummary(w io.Writer, deps []brief.DepInfo) {
-	if len(deps) == 0 {
-		return
-	}
-	directRuntime, directDev, totalRuntime, totalDev := 0, 0, 0, 0
-	for _, d := range deps {
-		if strings.HasPrefix(d.PURL, "pkg:githubactions/") || strings.HasPrefix(d.PURL, "pkg:docker/") {
-			continue
-		}
-		isDev := d.Scope == brief.ScopeDevelopment || d.Scope == brief.ScopeTest || d.Scope == brief.ScopeBuild
-		if isDev {
-			totalDev++
-			if d.Direct {
-				directDev++
-			}
-		} else {
-			totalRuntime++
-			if d.Direct {
-				directRuntime++
-			}
-		}
-	}
-	var parts []string
-	if directRuntime > 0 {
-		s := fmt.Sprintf("%d runtime", directRuntime)
-		if transitive := totalRuntime - directRuntime; transitive > 0 {
-			s += fmt.Sprintf(" (%d total)", totalRuntime)
-		}
-		parts = append(parts, s)
-	}
-	if directDev > 0 {
-		s := fmt.Sprintf("%d dev", directDev)
-		if transitive := totalDev - directDev; transitive > 0 {
-			s += fmt.Sprintf(" (%d total)", totalDev)
-		}
-		parts = append(parts, s)
-	}
-	if len(parts) > 0 {
-		_, _ = fmt.Fprintf(w, "                 %s\n", strings.Join(parts, ", "))
+	if s := depSummary(deps); s != "" {
+		_, _ = fmt.Fprintf(w, "                 %s\n", s)
 	}
 }
 
@@ -360,33 +324,13 @@ func printEnrichment(w io.Writer, e *brief.EnrichmentInfo) {
 	if len(e.RuntimeEOL) > 0 {
 		_, _ = fmt.Fprintln(w)
 		for name, eol := range e.RuntimeEOL {
-			status := "supported"
-			if !eol.Supported {
-				status = "EOL"
-			}
-			if eol.LTS {
-				status += ", LTS"
-			}
-			line := name + ": " + status
-			if eol.Latest != "" {
-				line += " (latest: " + eol.Latest + ")"
-			}
-			_, _ = fmt.Fprintf(w, "Runtime:     %s\n", line)
+			_, _ = fmt.Fprintf(w, "Runtime:     %s\n", enrichmentRuntimeLine(name, eol))
 		}
 	}
 	for _, pkg := range e.Packages {
 		_, _ = fmt.Fprintf(w, "Published:   %s (%s)\n", pkg.Name, pkg.Ecosystem)
-		if pkg.LatestVersion != "" {
-			_, _ = fmt.Fprintf(w, "             latest: %s\n", pkg.LatestVersion)
-		}
-		if pkg.Downloads > 0 {
-			_, _ = fmt.Fprintf(w, "             downloads: %d (%s)\n", pkg.Downloads, pkg.DownloadsPeriod)
-		}
-		if pkg.DependentReposCount > 0 {
-			_, _ = fmt.Fprintf(w, "             dependents: %d repos, %d packages\n", pkg.DependentReposCount, pkg.DependentPackagesCount)
-		}
-		if pkg.RegistryURL != "" {
-			_, _ = fmt.Fprintf(w, "             registry: %s\n", pkg.RegistryURL)
+		for _, line := range packageDetailLines(pkg) {
+			_, _ = fmt.Fprintf(w, "             %s\n", line)
 		}
 	}
 }
@@ -436,4 +380,80 @@ func detectionNames(ds []brief.Detection) []string {
 		names[i] = d.Name
 	}
 	return names
+}
+
+// depSummary computes a human-readable dependency summary string.
+// Returns empty string if there are no relevant dependencies.
+func depSummary(deps []brief.DepInfo) string {
+	if len(deps) == 0 {
+		return ""
+	}
+	directRuntime, directDev, totalRuntime, totalDev := 0, 0, 0, 0
+	for _, d := range deps {
+		if strings.HasPrefix(d.PURL, "pkg:githubactions/") || strings.HasPrefix(d.PURL, "pkg:docker/") {
+			continue
+		}
+		isDev := d.Scope == brief.ScopeDevelopment || d.Scope == brief.ScopeTest || d.Scope == brief.ScopeBuild
+		if isDev {
+			totalDev++
+			if d.Direct {
+				directDev++
+			}
+		} else {
+			totalRuntime++
+			if d.Direct {
+				directRuntime++
+			}
+		}
+	}
+	var parts []string
+	if directRuntime > 0 {
+		s := fmt.Sprintf("%d runtime", directRuntime)
+		if transitive := totalRuntime - directRuntime; transitive > 0 {
+			s += fmt.Sprintf(" (%d total)", totalRuntime)
+		}
+		parts = append(parts, s)
+	}
+	if directDev > 0 {
+		s := fmt.Sprintf("%d dev", directDev)
+		if transitive := totalDev - directDev; transitive > 0 {
+			s += fmt.Sprintf(" (%d total)", totalDev)
+		}
+		parts = append(parts, s)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// enrichmentRuntimeLine formats a single runtime EOL entry.
+func enrichmentRuntimeLine(name string, eol *brief.RuntimeEOL) string {
+	status := "supported"
+	if !eol.Supported {
+		status = "EOL"
+	}
+	if eol.LTS {
+		status += ", LTS"
+	}
+	line := name + ": " + status
+	if eol.Latest != "" {
+		line += " (latest: " + eol.Latest + ")"
+	}
+	return line
+}
+
+// packageDetailLines returns detail lines for a published package.
+func packageDetailLines(pkg brief.PublishedPackage) []string {
+	var lines []string
+	if pkg.LatestVersion != "" {
+		lines = append(lines, "latest: "+pkg.LatestVersion)
+	}
+	if pkg.Downloads > 0 {
+		lines = append(lines, fmt.Sprintf("downloads: %d (%s)", pkg.Downloads, pkg.DownloadsPeriod))
+	}
+	if pkg.DependentReposCount > 0 {
+		lines = append(lines, fmt.Sprintf("dependents: %d repos, %d packages", pkg.DependentReposCount, pkg.DependentPackagesCount))
+	}
+	if pkg.RegistryURL != "" {
+		lines = append(lines, "registry: "+pkg.RegistryURL)
+	}
+	return lines
 }


### PR DESCRIPTION
Adds a `-markdown` flag to all subcommands (scan, diff, missing, enrich) that outputs structured markdown with headers, tables, bold labels, and inline code for commands.

Also extracts shared formatting helpers (`depSummary`, `enrichmentRuntimeLine`, `packageDetailLines`) to eliminate duplication between human and markdown formatters.