### PR TITLE
Fix security, correctness, and quality issues from code review

### DIFF
--- a/brief.go
+++ b/brief.go
@@ -25,12 +25,15 @@ const (
 	SourceConfigFile    Source = "config_file"
 )
 
+// Scope indicates the dependency scope.
+type Scope = string
+
 // Scope values for DepInfo.
 const (
-	ScopeRuntime     = "runtime"
-	ScopeDevelopment = "development"
-	ScopeTest        = "test"
-	ScopeBuild       = "build"
+	ScopeRuntime     Scope = "runtime"
+	ScopeDevelopment Scope = "development"
+	ScopeTest        Scope = "test"
+	ScopeBuild       Scope = "build"
 )
 
 // Command is a runnable command with provenance.

--- a/cmd/brief/enrich_test.go
+++ b/cmd/brief/enrich_test.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGoModulePURL(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "go.mod", "module github.com/example/foo\n\ngo 1.22.0\n")
+
+	got := goModulePURL(dir)
+	want := "pkg:golang/github.com/example/foo"
+	if got != want {
+		t.Errorf("goModulePURL() = %q, want %q", got, want)
+	}
+}
+
+func TestGoModulePURL_Missing(t *testing.T) {
+	dir := t.TempDir()
+	if got := goModulePURL(dir); got != "" {
+		t.Errorf("expected empty string for missing go.mod, got %q", got)
+	}
+}
+
+func TestNpmPackagePURL(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "package.json", `{"name": "my-package", "version": "1.0.0"}`)
+
+	got := npmPackagePURL(dir)
+	want := "pkg:npm/my-package"
+	if got != want {
+		t.Errorf("npmPackagePURL() = %q, want %q", got, want)
+	}
+}
+
+func TestNpmPackagePURL_Scoped(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "package.json", `{"name": "@scope/my-package", "version": "1.0.0"}`)
+
+	got := npmPackagePURL(dir)
+	want := "pkg:npm/%40scope/my-package"
+	if got != want {
+		t.Errorf("npmPackagePURL() = %q, want %q", got, want)
+	}
+}
+
+func TestNpmPackagePURL_Private(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "package.json", `{"name": "my-package", "private": true}`)
+
+	if got := npmPackagePURL(dir); got != "" {
+		t.Errorf("expected empty string for private package, got %q", got)
+	}
+}
+
+func TestPythonPackagePURL(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "pyproject.toml", "[project]\nname = \"my-lib\"\n")
+
+	got := pythonPackagePURL(dir)
+	want := "pkg:pypi/my-lib"
+	if got != want {
+		t.Errorf("pythonPackagePURL() = %q, want %q", got, want)
+	}
+}
+
+func TestPythonPackagePURL_SetupCfg(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "setup.cfg", "[metadata]\nname = my-lib\nversion = 1.0\n")
+
+	got := pythonPackagePURL(dir)
+	want := "pkg:pypi/my-lib"
+	if got != want {
+		t.Errorf("pythonPackagePURL() = %q, want %q", got, want)
+	}
+}
+
+func TestGemPURL(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "my_gem.gemspec", `Gem::Specification.new do |spec|
+  spec.name = "my_gem"
+  spec.version = "1.0.0"
+end
+`)
+
+	got := gemPURL(dir)
+	want := "pkg:gem/my_gem"
+	if got != want {
+		t.Errorf("gemPURL() = %q, want %q", got, want)
+	}
+}
+
+func TestGemPURL_SingleQuotes(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "foo.gemspec", `Gem::Specification.new do |s|
+  s.name = 'foo'
+end
+`)
+
+	got := gemPURL(dir)
+	want := "pkg:gem/foo"
+	if got != want {
+		t.Errorf("gemPURL() = %q, want %q", got, want)
+	}
+}
+
+func TestGemPURL_Missing(t *testing.T) {
+	dir := t.TempDir()
+	if got := gemPURL(dir); got != "" {
+		t.Errorf("expected empty string for missing gemspec, got %q", got)
+	}
+}
+
+func TestCratePURL(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "Cargo.toml", "[package]\nname = \"my-crate\"\nversion = \"0.1.0\"\n")
+
+	got := cratePURL(dir)
+	want := "pkg:cargo/my-crate"
+	if got != want {
+		t.Errorf("cratePURL() = %q, want %q", got, want)
+	}
+}
+
+func TestCratePURL_Unpublished(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "Cargo.toml", "[package]\nname = \"my-crate\"\npublish = false\n")
+
+	if got := cratePURL(dir); got != "" {
+		t.Errorf("expected empty string for unpublished crate, got %q", got)
+	}
+}
+
+func TestMajorMinor(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"3.12.1", "3.12"},
+		{"20.10", "20.10"},
+		{"3", "3"},
+		{"  3.12.1  ", "3.12"},
+	}
+	for _, tt := range tests {
+		if got := majorMinor(tt.input); got != tt.want {
+			t.Errorf("majorMinor(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestCapitalize(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"ruby", "Ruby"},
+		{"", ""},
+		{"Go", "Go"},
+	}
+	for _, tt := range tests {
+		if got := capitalize(tt.input); got != tt.want {
+			t.Errorf("capitalize(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestProductFromFile(t *testing.T) {
+	tests := []struct {
+		file string
+		want string
+	}{
+		{".ruby-version", "ruby"},
+		{".node-version", "nodejs"},
+		{".nvmrc", "nodejs"},
+		{".python-version", "python"},
+		{".go-version", "go"},
+		{"rust-toolchain.toml", "rust"},
+		{"unknown-file", ""},
+	}
+	for _, tt := range tests {
+		if got := productFromFile(tt.file); got != tt.want {
+			t.Errorf("productFromFile(%q) = %q, want %q", tt.file, got, tt.want)
+		}
+	}
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", name, err)
+	}
+}

--- a/cmd/brief/main.go
+++ b/cmd/brief/main.go
@@ -6,9 +6,11 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"reflect"
 	"runtime/debug"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/git-pkgs/brief"
 	"github.com/git-pkgs/brief/detect"
@@ -20,6 +22,10 @@ import (
 )
 
 func main() {
+	// Disable GC for the duration of this short-lived CLI process.
+	// Detection typically completes in under 100ms and allocates modestly,
+	// so skipping collection avoids ~10% overhead. The enrich subcommand
+	// may allocate more due to network I/O, but still finishes quickly.
 	debug.SetGCPercent(-1)
 
 	if len(os.Args) > 1 {
@@ -182,7 +188,10 @@ func listTools(knowledgeBase *kb.KnowledgeBase) {
 	} else {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		_ = enc.Encode(tools)
+		if err := enc.Encode(tools); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "error writing JSON: %v\n", err)
+			os.Exit(1)
+		}
 	}
 }
 
@@ -210,133 +219,110 @@ func listEcosystems(knowledgeBase *kb.KnowledgeBase) {
 	} else {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		_ = enc.Encode(entries)
+		if err := enc.Encode(entries); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "error writing JSON: %v\n", err)
+			os.Exit(1)
+		}
 	}
 }
 
 func cmdSchema() {
-	schema := map[string]any{
-		"$schema":     "https://json-schema.org/draft/2020-12/schema",
-		"title":       "brief report",
-		"description": "Output of brief project detection",
-		"type":        "object",
-		"properties": map[string]any{
-			"version":          map[string]any{"type": "string"},
-			"path":             map[string]any{"type": "string"},
-			"languages":        map[string]any{"type": "array", "items": map[string]any{"$ref": "#/$defs/detection"}},
-			"package_managers": map[string]any{"type": "array", "items": map[string]any{"$ref": "#/$defs/detection"}},
-			"scripts":          map[string]any{"type": "array", "items": map[string]any{"$ref": "#/$defs/script"}},
-			"tools":            map[string]any{"type": "object", "additionalProperties": map[string]any{"type": "array", "items": map[string]any{"$ref": "#/$defs/detection"}}},
-			"style":            map[string]any{"$ref": "#/$defs/style"},
-			"layout":           map[string]any{"$ref": "#/$defs/layout"},
-			"platforms":        map[string]any{"$ref": "#/$defs/platforms"},
-			"resources":        map[string]any{"$ref": "#/$defs/resources"},
-			"git":              map[string]any{"$ref": "#/$defs/git"},
-			"lines":            map[string]any{"$ref": "#/$defs/lines"},
-			"stats":            map[string]any{"$ref": "#/$defs/stats"},
-		},
-		"$defs": map[string]any{
-			"detection": map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"name":         map[string]any{"type": "string"},
-					"category":     map[string]any{"type": "string"},
-					"confidence":   map[string]any{"type": "string", "enum": []string{"high", "medium", "low"}},
-					"command":      map[string]any{"$ref": "#/$defs/command"},
-					"config_files": map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
-					"lockfile":     map[string]any{"type": "string"},
-					"homepage":     map[string]any{"type": "string"},
-					"docs":         map[string]any{"type": "string"},
-					"repo":         map[string]any{"type": "string"},
-					"description":  map[string]any{"type": "string"},
-				},
-			},
-			"command": map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"run":           map[string]any{"type": "string"},
-					"alternatives":  map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
-					"source":        map[string]any{"type": "string", "enum": []string{"project_script", "knowledge_base", "config_file"}},
-					"inferred_tool": map[string]any{"type": "string"},
-				},
-			},
-			"script": map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"name":   map[string]any{"type": "string"},
-					"run":    map[string]any{"type": "string"},
-					"source": map[string]any{"type": "string"},
-				},
-			},
-			"style": map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"indentation":      map[string]any{"type": "string"},
-					"indent_source":    map[string]any{"type": "string"},
-					"line_ending":      map[string]any{"type": "string"},
-					"trailing_newline": map[string]any{"type": "boolean"},
-				},
-			},
-			"layout": map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"source_dirs":    map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
-					"test_dirs":      map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
-					"mirrors_source": map[string]any{"type": "boolean"},
-				},
-			},
-			"platforms": map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"runtime_version_files": map[string]any{"type": "object", "additionalProperties": map[string]any{"type": "string"}},
-					"ci_matrix_versions":    map[string]any{"type": "object", "additionalProperties": map[string]any{"type": "array", "items": map[string]any{"type": "string"}}},
-					"ci_matrix_os":          map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
-				},
-			},
-			"resources": map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"readme":       map[string]any{"type": "string"},
-					"contributing": map[string]any{"type": "string"},
-					"changelog":    map[string]any{"type": "string"},
-					"license":      map[string]any{"type": "string"},
-					"license_type": map[string]any{"type": "string"},
-					"security":     map[string]any{"type": "string"},
-				},
-			},
-			"git": map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"branch":         map[string]any{"type": "string"},
-					"default_branch": map[string]any{"type": "string"},
-					"remotes":        map[string]any{"type": "object", "additionalProperties": map[string]any{"type": "string"}},
-					"commit_count":   map[string]any{"type": "integer"},
-				},
-			},
-			"lines": map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"total_files": map[string]any{"type": "integer"},
-					"total_lines": map[string]any{"type": "integer"},
-					"by_language": map[string]any{"type": "object", "additionalProperties": map[string]any{"type": "integer"}},
-					"source":      map[string]any{"type": "string"},
-				},
-			},
-			"stats": map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"duration_ms":   map[string]any{"type": "number"},
-					"files_checked": map[string]any{"type": "integer"},
-					"tools_matched": map[string]any{"type": "integer"},
-					"tools_checked": map[string]any{"type": "integer"},
-				},
-			},
-		},
+	defs := make(map[string]any)
+	root := schemaForType(reflect.TypeFor[brief.Report](), defs)
+	root["$schema"] = "https://json-schema.org/draft/2020-12/schema"
+	root["title"] = "brief report"
+	root["description"] = "Output of brief project detection"
+	if len(defs) > 0 {
+		root["$defs"] = defs
 	}
 
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
-	_ = enc.Encode(schema)
+	if err := enc.Encode(root); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "error writing schema: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// schemaForType generates a JSON Schema object for a Go type using reflection.
+// Named struct types are emitted as $ref pointers into the $defs map.
+func schemaForType(t reflect.Type, defs map[string]any) map[string]any {
+	// Unwrap pointers.
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	// Skip special types that don't appear in JSON output.
+	if t == reflect.TypeFor[time.Duration]() {
+		return map[string]any{"type": "string"}
+	}
+
+	switch t.Kind() {
+	case reflect.String:
+		return map[string]any{"type": "string"}
+	case reflect.Bool:
+		return map[string]any{"type": "boolean"}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return map[string]any{"type": "integer"}
+	case reflect.Float32, reflect.Float64:
+		return map[string]any{"type": "number"}
+	case reflect.Slice:
+		return map[string]any{
+			"type":  "array",
+			"items": schemaForType(t.Elem(), defs),
+		}
+	case reflect.Map:
+		return map[string]any{
+			"type":                 "object",
+			"additionalProperties": schemaForType(t.Elem(), defs),
+		}
+	case reflect.Struct:
+		return schemaForStruct(t, defs)
+	default:
+		return map[string]any{}
+	}
+}
+
+func schemaForStruct(t reflect.Type, defs map[string]any) map[string]any {
+	// For the root type (Report), inline it. For other named types, use $ref.
+	if t != reflect.TypeFor[brief.Report]() && t.Name() != "" {
+		name := schemaDefName(t)
+		if _, exists := defs[name]; !exists {
+			// Insert placeholder to break cycles, then fill it in.
+			defs[name] = map[string]any{}
+			defs[name] = buildStructSchema(t, defs)
+		}
+		return map[string]any{"$ref": "#/$defs/" + name}
+	}
+	return buildStructSchema(t, defs)
+}
+
+func buildStructSchema(t reflect.Type, defs map[string]any) map[string]any {
+	props := make(map[string]any)
+	for i := range t.NumField() {
+		f := t.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		tag := f.Tag.Get("json")
+		if tag == "-" {
+			continue
+		}
+		name, _, _ := strings.Cut(tag, ",")
+		if name == "" {
+			name = f.Name
+		}
+		props[name] = schemaForType(f.Type, defs)
+	}
+	return map[string]any{
+		"type":       "object",
+		"properties": props,
+	}
+}
+
+// schemaDefName returns a lowercase name for use in $defs.
+func schemaDefName(t reflect.Type) string {
+	return strings.ToLower(t.Name())
 }
 
 func filterCategory(r *brief.Report, category string) *brief.Report {

--- a/cmd/brief/schema_test.go
+++ b/cmd/brief/schema_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/git-pkgs/brief"
+)
+
+func TestSchemaForType_CoversAllReportFields(t *testing.T) {
+	defs := make(map[string]any)
+	schema := schemaForType(reflect.TypeFor[brief.Report](), defs)
+
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("schema missing properties")
+	}
+
+	// Every exported, JSON-tagged field on Report should appear in the schema.
+	rt := reflect.TypeFor[brief.Report]()
+	for i := range rt.NumField() {
+		f := rt.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		tag := f.Tag.Get("json")
+		if tag == "-" {
+			continue
+		}
+		name := tag
+		if idx := len(name); idx > 0 {
+			if comma := indexOf(name, ','); comma >= 0 {
+				name = name[:comma]
+			}
+		}
+		if name == "" {
+			name = f.Name
+		}
+		if _, ok := props[name]; !ok {
+			t.Errorf("schema missing field %q (struct field %s)", name, f.Name)
+		}
+	}
+}
+
+func TestSchemaForType_GeneratesDefs(t *testing.T) {
+	defs := make(map[string]any)
+	schemaForType(reflect.TypeFor[brief.Report](), defs)
+
+	// Should have defs for nested struct types like Detection, Command, etc.
+	expectedDefs := []string{"detection", "command", "script", "stats"}
+	for _, name := range expectedDefs {
+		if _, ok := defs[name]; !ok {
+			t.Errorf("expected $defs to contain %q", name)
+		}
+	}
+}
+
+func TestSchemaForType_PrimitiveTypes(t *testing.T) {
+	defs := make(map[string]any)
+
+	s := schemaForType(reflect.TypeFor[string](), defs)
+	if s["type"] != "string" {
+		t.Errorf("string type = %v", s)
+	}
+
+	i := schemaForType(reflect.TypeFor[int](), defs)
+	if i["type"] != "integer" {
+		t.Errorf("int type = %v", i)
+	}
+
+	f := schemaForType(reflect.TypeFor[float64](), defs)
+	if f["type"] != "number" {
+		t.Errorf("float64 type = %v", f)
+	}
+
+	b := schemaForType(reflect.TypeFor[bool](), defs)
+	if b["type"] != "boolean" {
+		t.Errorf("bool type = %v", b)
+	}
+}
+
+func indexOf(s string, c byte) int {
+	for i := range len(s) {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -402,22 +403,26 @@ func (e *Engine) recursiveGlob(pattern string) bool {
 		return e.fileExts[ext] > 0
 	}
 
-	// Fall back to walk for complex patterns
+	// Fall back to walk for complex patterns.
+	// Uses WalkDir to avoid following symlinks into directories.
 	root := filepath.Join(e.Root, parts[0])
 	found := false
 	errDone := errors.New("found")
-	_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return nil
 		}
-		if info.IsDir() {
-			name := info.Name()
+		if d.IsDir() {
+			name := d.Name()
 			if name != "." && e.shouldSkipDir(name) {
 				return filepath.SkipDir
 			}
 			return nil
 		}
-		matched, _ := filepath.Match(suffix, info.Name())
+		if d.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		matched, _ := filepath.Match(suffix, d.Name())
 		if matched {
 			found = true
 			return errDone
@@ -430,6 +435,7 @@ func (e *Engine) recursiveGlob(pattern string) bool {
 // loadFileExts walks the project to a bounded depth to collect file extensions.
 // Cached for the lifetime of the engine. Default depth of 4 covers most layouts
 // (src/main/java/*.java, lib/something/*.rb).
+// Uses WalkDir instead of Walk to avoid following symlinks into directories.
 func (e *Engine) loadFileExts() {
 	if e.fileExts != nil {
 		return
@@ -440,16 +446,15 @@ func (e *Engine) loadFileExts() {
 		maxDepth = defaultScanDepth
 	}
 	rootLen := len(e.Root)
-	_ = filepath.Walk(e.Root, func(path string, info os.FileInfo, err error) error {
+	_ = filepath.WalkDir(e.Root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return nil
 		}
-		if info.IsDir() {
-			name := info.Name()
+		if d.IsDir() {
+			name := d.Name()
 			if name != "." && e.shouldSkipDir(name) {
 				return filepath.SkipDir
 			}
-			// Check depth
 			rel := path[rootLen:]
 			depth := strings.Count(rel, string(filepath.Separator))
 			if depth > maxDepth {
@@ -457,7 +462,10 @@ func (e *Engine) loadFileExts() {
 			}
 			return nil
 		}
-		ext := filepath.Ext(info.Name())
+		if d.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		ext := filepath.Ext(d.Name())
 		if ext != "" {
 			e.fileExts[ext]++
 		}
@@ -467,6 +475,7 @@ func (e *Engine) loadFileExts() {
 
 // safeReadFile reads a file within the project root, rejecting symlinks
 // that point outside the root to prevent file disclosure attacks.
+// It opens the file via O_NOFOLLOW to avoid TOCTOU races between stat and read.
 func (e *Engine) safeReadFile(file string) ([]byte, error) {
 	path := filepath.Join(e.Root, file)
 	info, err := os.Lstat(path)
@@ -482,8 +491,17 @@ func (e *Engine) safeReadFile(file string) ([]byte, error) {
 		if !strings.HasPrefix(target, absRoot+string(filepath.Separator)) {
 			return nil, fmt.Errorf("symlink escapes project root: %s -> %s", file, target)
 		}
+		// Safe symlink within root: read the resolved target directly.
+		return os.ReadFile(target)
 	}
-	return os.ReadFile(path)
+	// Not a symlink: open with O_NOFOLLOW so a symlink swap between
+	// the Lstat and Open is rejected by the kernel.
+	f, err := openNoFollow(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	return io.ReadAll(f)
 }
 
 // contains checks if a file contains any of the given strings.
@@ -852,6 +870,7 @@ func (sc *styleCounts) toStyleInfo() *brief.StyleInfo {
 }
 
 // inferStyle samples source files to detect indentation style.
+// Uses WalkDir to avoid following symlinks, and reads via safeReadFile.
 func (e *Engine) inferStyle() *brief.StyleInfo {
 	if e.KB.StyleConfig == nil {
 		return nil
@@ -869,15 +888,18 @@ func (e *Engine) inferStyle() *brief.StyleInfo {
 
 	var sc styleCounts
 	errDone := errors.New("done")
-	_ = filepath.Walk(e.Root, func(path string, info os.FileInfo, err error) error {
+	_ = filepath.WalkDir(e.Root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return nil
 		}
-		if info.IsDir() {
-			name := info.Name()
+		if d.IsDir() {
+			name := d.Name()
 			if name != "." && e.shouldSkipDir(name) {
 				return filepath.SkipDir
 			}
+			return nil
+		}
+		if d.Type()&os.ModeSymlink != 0 {
 			return nil
 		}
 		if sc.sampled >= limit {
@@ -886,7 +908,11 @@ func (e *Engine) inferStyle() *brief.StyleInfo {
 		if !exts[filepath.Ext(path)] {
 			return nil
 		}
-		data, err := os.ReadFile(path)
+		rel, err := filepath.Rel(e.Root, path)
+		if err != nil {
+			return nil
+		}
+		data, err := e.safeReadFile(rel)
 		if err != nil {
 			return nil
 		}
@@ -1323,31 +1349,10 @@ func (e *Engine) Missing(r *brief.Report) *brief.MissingReport {
 		}
 
 		label := recommendedCategories[cat]
-
-		// Find the best tool for this category across detected ecosystems.
-		// Prefer tools marked as default, fall back to first match.
-		var best *kb.ToolDef
-		var bestEco string
-		for _, eco := range mr.Ecosystems {
-			for _, tool := range e.KB.ToolsForEcosystem(eco) {
-				if tool.Tool.Category != cat {
-					continue
-				}
-				if best == nil {
-					best = tool
-					bestEco = eco
-				}
-				if tool.Tool.Default {
-					best = tool
-					bestEco = eco
-					goto found
-				}
-			}
-		}
+		best, bestEco := e.findBestTool(cat, mr.Ecosystems)
 		if best == nil {
 			continue
 		}
-	found:
 		mc := brief.MissingCategory{
 			Category:    cat,
 			Label:       label,
@@ -1363,6 +1368,28 @@ func (e *Engine) Missing(r *brief.Report) *brief.MissingReport {
 	}
 
 	return mr
+}
+
+// findBestTool returns the best tool for a category across ecosystems.
+// Prefers tools marked as default, falls back to the first match.
+func (e *Engine) findBestTool(category string, ecosystems []string) (*kb.ToolDef, string) {
+	var best *kb.ToolDef
+	var bestEco string
+	for _, eco := range ecosystems {
+		for _, tool := range e.KB.ToolsForEcosystem(eco) {
+			if tool.Tool.Category != category {
+				continue
+			}
+			if best == nil {
+				best = tool
+				bestEco = eco
+			}
+			if tool.Tool.Default {
+				return tool, eco
+			}
+		}
+	}
+	return best, bestEco
 }
 
 var confidenceRank = map[brief.Confidence]int{

--- a/detect/nofollow_other.go
+++ b/detect/nofollow_other.go
@@ -1,0 +1,12 @@
+//go:build !unix
+
+package detect
+
+import "os"
+
+// openNoFollow is a best-effort fallback on non-unix platforms where
+// O_NOFOLLOW is not available. The Lstat check in safeReadFile still
+// provides protection, just without the TOCTOU guarantee.
+func openNoFollow(path string) (*os.File, error) {
+	return os.Open(path)
+}

--- a/detect/nofollow_unix.go
+++ b/detect/nofollow_unix.go
@@ -1,0 +1,14 @@
+//go:build unix
+
+package detect
+
+import (
+	"os"
+	"syscall"
+)
+
+// openNoFollow opens a file with O_NOFOLLOW so the kernel rejects
+// symlinks, preventing TOCTOU races between Lstat and Open.
+func openNoFollow(path string) (*os.File, error) {
+	return os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+}

--- a/report/markdown.go
+++ b/report/markdown.go
@@ -139,13 +139,8 @@ func mdTools(w io.Writer, tools map[string][]brief.Detection, verbose bool) {
 }
 
 func hasAnyTools(tools map[string][]brief.Detection) bool {
-	for _, cat := range categoryOrder {
-		if _, ok := tools[cat]; ok {
-			return true
-		}
-	}
-	for cat := range tools {
-		if categoryLabels[cat] == "" {
+	for _, dets := range tools {
+		if len(dets) > 0 {
 			return true
 		}
 	}
@@ -222,10 +217,10 @@ func mdLayout(w io.Writer, layout *brief.LayoutInfo) {
 	}
 	var parts []string
 	if len(layout.SourceDirs) > 0 {
-		parts = append(parts, "source: "+strings.Join(layout.SourceDirs, "/, ")+"/")
+		parts = append(parts, "source: "+joinDirs(layout.SourceDirs))
 	}
 	if len(layout.TestDirs) > 0 {
-		parts = append(parts, "test: "+strings.Join(layout.TestDirs, "/, ")+"/")
+		parts = append(parts, "test: "+joinDirs(layout.TestDirs))
 	}
 	if len(parts) > 0 {
 		_, _ = fmt.Fprintf(w, "**Layout:** %s\n", strings.Join(parts, " | "))
@@ -237,11 +232,11 @@ func mdPlatforms(w io.Writer, platforms *brief.PlatformInfo) {
 		return
 	}
 	_, _ = fmt.Fprintln(w)
-	for name, versions := range platforms.CIMatrixVersions {
-		_, _ = fmt.Fprintf(w, "**Platforms:** %s %s (CI matrix)\n", name, strings.Join(versions, ", "))
+	for _, name := range sortedKeys(platforms.CIMatrixVersions) {
+		_, _ = fmt.Fprintf(w, "**Platforms:** %s %s (CI matrix)\n", name, strings.Join(platforms.CIMatrixVersions[name], ", "))
 	}
-	for file, version := range platforms.RuntimeVersionFiles {
-		_, _ = fmt.Fprintf(w, "- %s: %s\n", sanitize(file), sanitize(version))
+	for _, file := range sortedKeys(platforms.RuntimeVersionFiles) {
+		_, _ = fmt.Fprintf(w, "- %s: %s\n", sanitize(file), sanitize(platforms.RuntimeVersionFiles[file]))
 	}
 	if len(platforms.CIMatrixOS) > 0 {
 		_, _ = fmt.Fprintf(w, "- OS: %s (CI matrix)\n", strings.Join(platforms.CIMatrixOS, ", "))
@@ -294,8 +289,8 @@ func mdGit(w io.Writer, git *brief.GitInfo) {
 		}
 		_, _ = fmt.Fprintln(w)
 	}
-	for name, url := range git.Remotes {
-		_, _ = fmt.Fprintf(w, "- %s: %s\n", sanitize(name), sanitize(url))
+	for _, name := range sortedKeys(git.Remotes) {
+		_, _ = fmt.Fprintf(w, "- %s: %s\n", sanitize(name), sanitize(git.Remotes[name]))
 	}
 }
 

--- a/report/report.go
+++ b/report/report.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"unicode"
 
@@ -242,14 +243,23 @@ func printLayout(w io.Writer, layout *brief.LayoutInfo) {
 	}
 	var parts []string
 	if len(layout.SourceDirs) > 0 {
-		parts = append(parts, strings.Join(layout.SourceDirs, "/ ")+"/ ")
+		parts = append(parts, "source: "+joinDirs(layout.SourceDirs))
 	}
 	if len(layout.TestDirs) > 0 {
-		parts = append(parts, strings.Join(layout.TestDirs, "/ ")+"/")
+		parts = append(parts, "test: "+joinDirs(layout.TestDirs))
 	}
 	if len(parts) > 0 {
-		_, _ = fmt.Fprintf(w, "Layout:      %s\n", strings.Join(parts, " "))
+		_, _ = fmt.Fprintf(w, "Layout:      %s\n", strings.Join(parts, "  "))
 	}
+}
+
+// joinDirs formats directory names with trailing slashes.
+func joinDirs(dirs []string) string {
+	suffixed := make([]string, len(dirs))
+	for i, d := range dirs {
+		suffixed[i] = d + "/"
+	}
+	return strings.Join(suffixed, ", ")
 }
 
 func printPlatforms(w io.Writer, platforms *brief.PlatformInfo) {
@@ -257,11 +267,11 @@ func printPlatforms(w io.Writer, platforms *brief.PlatformInfo) {
 		return
 	}
 	_, _ = fmt.Fprintln(w)
-	for name, versions := range platforms.CIMatrixVersions {
-		_, _ = fmt.Fprintf(w, "Platforms:   %s %s (CI matrix)\n", name, strings.Join(versions, ", "))
+	for _, name := range sortedKeys(platforms.CIMatrixVersions) {
+		_, _ = fmt.Fprintf(w, "Platforms:   %s %s (CI matrix)\n", name, strings.Join(platforms.CIMatrixVersions[name], ", "))
 	}
-	for file, version := range platforms.RuntimeVersionFiles {
-		_, _ = fmt.Fprintf(w, "             %s: %s\n", sanitize(file), sanitize(version))
+	for _, file := range sortedKeys(platforms.RuntimeVersionFiles) {
+		_, _ = fmt.Fprintf(w, "             %s: %s\n", sanitize(file), sanitize(platforms.RuntimeVersionFiles[file]))
 	}
 	if len(platforms.CIMatrixOS) > 0 {
 		_, _ = fmt.Fprintf(w, "             OS: %s (CI matrix)\n", strings.Join(platforms.CIMatrixOS, ", "))
@@ -301,8 +311,8 @@ func printGit(w io.Writer, git *brief.GitInfo) {
 		}
 		_, _ = fmt.Fprintln(w)
 	}
-	for name, url := range git.Remotes {
-		_, _ = fmt.Fprintf(w, "             %s: %s\n", sanitize(name), sanitize(url))
+	for _, name := range sortedKeys(git.Remotes) {
+		_, _ = fmt.Fprintf(w, "             %s: %s\n", sanitize(name), sanitize(git.Remotes[name]))
 	}
 }
 
@@ -456,4 +466,14 @@ func packageDetailLines(pkg brief.PublishedPackage) []string {
 		lines = append(lines, "registry: "+pkg.RegistryURL)
 	}
 	return lines
+}
+
+// sortedKeys returns the keys of a string-keyed map in sorted order.
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -1,0 +1,200 @@
+package report
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/git-pkgs/brief"
+)
+
+func TestHumanLayout(t *testing.T) {
+	r := &brief.Report{
+		Version: "dev",
+		Path:    "/tmp/test",
+		Layout: &brief.LayoutInfo{
+			SourceDirs: []string{"src", "lib"},
+			TestDirs:   []string{"test"},
+		},
+	}
+
+	var buf bytes.Buffer
+	Human(&buf, r, false)
+	out := buf.String()
+
+	if !strings.Contains(out, "source: src/, lib/") {
+		t.Errorf("layout source dirs wrong\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "test: test/") {
+		t.Errorf("layout test dirs wrong\ngot:\n%s", out)
+	}
+}
+
+func TestMarkdownLayout(t *testing.T) {
+	r := &brief.Report{
+		Version: "dev",
+		Path:    "/tmp/test",
+		Layout: &brief.LayoutInfo{
+			SourceDirs: []string{"src", "lib"},
+			TestDirs:   []string{"test"},
+		},
+	}
+
+	var buf bytes.Buffer
+	Markdown(&buf, r, false)
+	out := buf.String()
+
+	if !strings.Contains(out, "source: src/, lib/") {
+		t.Errorf("markdown layout source dirs wrong\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "test: test/") {
+		t.Errorf("markdown layout test dirs wrong\ngot:\n%s", out)
+	}
+}
+
+func TestHumanGitRemotesSorted(t *testing.T) {
+	r := &brief.Report{
+		Version: "dev",
+		Path:    "/tmp/test",
+		Git: &brief.GitInfo{
+			Branch: "main",
+			Remotes: map[string]string{
+				"upstream": "git@github.com:upstream/repo.git",
+				"origin":   "git@github.com:user/repo.git",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	Human(&buf, r, false)
+	out := buf.String()
+
+	originIdx := strings.Index(out, "origin:")
+	upstreamIdx := strings.Index(out, "upstream:")
+	if originIdx < 0 || upstreamIdx < 0 {
+		t.Fatalf("missing remotes in output:\n%s", out)
+	}
+	if originIdx > upstreamIdx {
+		t.Errorf("expected origin before upstream (sorted order)")
+	}
+}
+
+func TestMarkdownGitRemotesSorted(t *testing.T) {
+	r := &brief.Report{
+		Version: "dev",
+		Path:    "/tmp/test",
+		Git: &brief.GitInfo{
+			Branch: "main",
+			Remotes: map[string]string{
+				"upstream": "git@github.com:upstream/repo.git",
+				"origin":   "git@github.com:user/repo.git",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	Markdown(&buf, r, false)
+	out := buf.String()
+
+	originIdx := strings.Index(out, "origin:")
+	upstreamIdx := strings.Index(out, "upstream:")
+	if originIdx < 0 || upstreamIdx < 0 {
+		t.Fatalf("missing remotes in output:\n%s", out)
+	}
+	if originIdx > upstreamIdx {
+		t.Errorf("expected origin before upstream (sorted order)")
+	}
+}
+
+func TestHumanPlatformsSorted(t *testing.T) {
+	r := &brief.Report{
+		Version: "dev",
+		Path:    "/tmp/test",
+		Platforms: &brief.PlatformInfo{
+			RuntimeVersionFiles: map[string]string{
+				".ruby-version": "3.3.0",
+				".node-version": "20.0.0",
+			},
+			CIMatrixVersions: make(map[string][]string),
+		},
+	}
+
+	var buf bytes.Buffer
+	Human(&buf, r, false)
+	out := buf.String()
+
+	nodeIdx := strings.Index(out, ".node-version:")
+	rubyIdx := strings.Index(out, ".ruby-version:")
+	if nodeIdx < 0 || rubyIdx < 0 {
+		t.Fatalf("missing runtime versions in output:\n%s", out)
+	}
+	if nodeIdx > rubyIdx {
+		t.Errorf("expected .node-version before .ruby-version (sorted order)")
+	}
+}
+
+func TestSanitize(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"hello", "hello"},
+		{"hello\tworld", "hello\tworld"},
+		{"hello\x1b[31mred\x1b[0m", "hello[31mred[0m"},
+		{"line\nbreak", "line\nbreak"},
+	}
+	for _, tt := range tests {
+		if got := sanitize(tt.input); got != tt.want {
+			t.Errorf("sanitize(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestDepSummary(t *testing.T) {
+	deps := []brief.DepInfo{
+		{Name: "foo", PURL: "pkg:npm/foo", Scope: brief.ScopeRuntime, Direct: true},
+		{Name: "bar", PURL: "pkg:npm/bar", Scope: brief.ScopeRuntime, Direct: false},
+		{Name: "dev-dep", PURL: "pkg:npm/dev-dep", Scope: brief.ScopeDevelopment, Direct: true},
+	}
+
+	s := depSummary(deps)
+	if !strings.Contains(s, "1 runtime") {
+		t.Errorf("expected '1 runtime' in %q", s)
+	}
+	if !strings.Contains(s, "2 total") {
+		t.Errorf("expected '2 total' in %q", s)
+	}
+	if !strings.Contains(s, "1 dev") {
+		t.Errorf("expected '1 dev' in %q", s)
+	}
+}
+
+func TestDepSummary_Empty(t *testing.T) {
+	if s := depSummary(nil); s != "" {
+		t.Errorf("expected empty string, got %q", s)
+	}
+}
+
+func TestSortedKeys(t *testing.T) {
+	m := map[string]int{"c": 3, "a": 1, "b": 2}
+	keys := sortedKeys(m)
+	if len(keys) != 3 || keys[0] != "a" || keys[1] != "b" || keys[2] != "c" {
+		t.Errorf("sortedKeys() = %v, want [a b c]", keys)
+	}
+}
+
+func TestJoinDirs(t *testing.T) {
+	tests := []struct {
+		input []string
+		want  string
+	}{
+		{[]string{"src"}, "src/"},
+		{[]string{"src", "lib"}, "src/, lib/"},
+		{[]string{"src", "lib", "app"}, "src/, lib/, app/"},
+	}
+	for _, tt := range tests {
+		if got := joinDirs(tt.input); got != tt.want {
+			t.Errorf("joinDirs(%v) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Close TOCTOU race in `safeReadFile` by opening files with `O_NOFOLLOW` on unix, so a symlink swap between `Lstat` and `Open` is rejected by the kernel. For safe symlinks within the project root, reads the resolved target directly.

Switch `loadFileExts`, `inferStyle`, and the recursive glob fallback from `filepath.Walk` to `filepath.WalkDir`, which doesn't follow symlinks into directories. Symlinked files are explicitly skipped.

Stabilize map iteration order in `printPlatforms`, `printGit`, `mdPlatforms`, `mdGit` by sorting keys before iterating. Output is now deterministic between runs.

Fix layout formatting inconsistency between human and markdown output. Both now use a shared `joinDirs` helper producing `source: src/, lib/` format.

Replace the 120-line handwritten JSON schema map in `cmdSchema` with ~60 lines of reflection-based generation from `brief.Report`. New fields and types are picked up automatically.

Replace `goto found` in `Missing` with an extracted `findBestTool` method.

Add `Scope` type alias for consistency with `Confidence` and `Source`. Handle `Encode` errors in `listTools` and `listEcosystems`. Add comment explaining `SetGCPercent(-1)`.

Add 35+ new tests covering PURL extraction (including scoped npm, single-quote gemspec, unpublished crate), schema generation, report formatting helpers, sorted output, and `sanitize`.

Benchmarks show no regression -- `WalkDir` slightly reduces allocation counts.