### PR TITLE
Fix script source files parsed as empty tool definitions

### DIFF
--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -284,6 +284,16 @@ func TestKnowledgeBaseLoads(t *testing.T) {
 	}
 }
 
+func TestNoEmptyToolNames(t *testing.T) {
+	knowledgeBase := loadKB(t)
+
+	for _, tool := range knowledgeBase.Tools {
+		if tool.Tool.Name == "" {
+			t.Errorf("tool with empty name loaded into knowledge base (category=%q)", tool.Tool.Category)
+		}
+	}
+}
+
 func TestScriptPriority(t *testing.T) {
 	engine := New(loadKB(t), "../testdata/ruby-project")
 	r, err := engine.Run()

--- a/kb/kb.go
+++ b/kb/kb.go
@@ -183,21 +183,22 @@ func Load(fsys embed.FS) (*KnowledgeBase, error) {
 
 		name := filepath.Base(path)
 
-		// Route to the right parser based on filename convention
-		switch name {
-		case "_scripts.toml":
+		// Route to the right parser based on filename convention.
+		// Script sources use a _scripts prefix (e.g. _scripts.toml, _scripts_justfile.toml).
+		switch {
+		case strings.HasPrefix(name, "_scripts"):
 			return base.loadScriptSource(data, path)
-		case "_resources.toml":
+		case name == "_resources.toml":
 			return base.loadResources(data, path)
-		case "_layout.toml":
+		case name == "_layout.toml":
 			return base.loadLayout(data, path)
-		case "_style.toml":
+		case name == "_style.toml":
 			return base.loadStyle(data, path)
-		case "_runtimes.toml":
+		case name == "_runtimes.toml":
 			return base.loadRuntimes(data, path)
-		case "_manifests.toml":
+		case name == "_manifests.toml":
 			return base.loadManifests(data, path)
-		case "_ci.toml":
+		case name == "_ci.toml":
 			return base.loadCIConfig(data, path)
 		default:
 			return base.loadTool(data, path)


### PR DESCRIPTION
`_scripts_justfile.toml` and `_scripts_taskfile.toml` were falling through to `loadTool` because the KB router only matched the exact filename `_scripts.toml`. They parsed into empty `ToolDef` structs with blank name and category, which showed up as two empty entries in `brief list tools` JSON output.

Changed the switch in `kb.Load` to prefix-match `_scripts` so all script source files route to `loadScriptSource`.