### PR TITLE
Add [taxonomy] and [security] sections to KB schema

### DIFF
--- a/brief.go
+++ b/brief.go
@@ -56,6 +56,18 @@ type Detection struct {
 	Docs        string     `json:"docs,omitempty"`
 	Repo        string     `json:"repo,omitempty"`
 	Description string     `json:"description,omitempty"`
+	Taxonomy    *Taxonomy  `json:"taxonomy,omitempty"`
+}
+
+// Taxonomy holds oss-taxonomy facet classifications carried through from
+// the tool definition. Values are kebab-case term IDs.
+type Taxonomy struct {
+	Role       []string `json:"role,omitempty"`
+	Function   []string `json:"function,omitempty"`
+	Layer      []string `json:"layer,omitempty"`
+	Domain     []string `json:"domain,omitempty"`
+	Audience   []string `json:"audience,omitempty"`
+	Technology []string `json:"technology,omitempty"`
 }
 
 // Script is a project-defined task (Makefile target, package.json script, etc.).
@@ -165,6 +177,47 @@ type RuntimeEOL struct {
 	Supported bool   `json:"supported"`
 	LTS       bool   `json:"lts,omitempty"`
 	Latest    string `json:"latest,omitempty"` // latest patch version
+}
+
+// ThreatReport is the output of brief threat-model.
+type ThreatReport struct {
+	Version    string       `json:"version"`
+	Path       string       `json:"path"`
+	Ecosystems []string     `json:"ecosystems"`
+	Stack      []StackEntry `json:"stack"`
+	Threats    []Threat     `json:"threats"`
+}
+
+// StackEntry is a detected tool that contributed to the threat model.
+type StackEntry struct {
+	Name     string    `json:"name"`
+	Taxonomy *Taxonomy `json:"taxonomy,omitempty"`
+}
+
+// Threat is a threat category that applies to the project's stack.
+type Threat struct {
+	ID           string   `json:"id"`
+	CWE          string   `json:"cwe,omitempty"`
+	OWASP        string   `json:"owasp,omitempty"`
+	Title        string   `json:"title"`
+	IntroducedBy []string `json:"introduced_by"`
+	Note         string   `json:"note,omitempty"`
+}
+
+// SinkReport is the output of brief sinks.
+type SinkReport struct {
+	Version string      `json:"version"`
+	Path    string      `json:"path"`
+	Sinks   []SinkEntry `json:"sinks"`
+}
+
+// SinkEntry is a known dangerous function in a detected tool.
+type SinkEntry struct {
+	Symbol string `json:"symbol"`
+	Tool   string `json:"tool"`
+	Threat string `json:"threat"`
+	CWE    string `json:"cwe,omitempty"`
+	Note   string `json:"note,omitempty"`
 }
 
 // MissingReport is the output of a brief missing analysis.

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -303,6 +303,17 @@ func (e *Engine) detectCategory(category string) []brief.Detection {
 			Description: tool.Tool.Description,
 		}
 
+		if !tool.Taxonomy.Empty() {
+			d.Taxonomy = &brief.Taxonomy{
+				Role:       tool.Taxonomy.Role,
+				Function:   tool.Taxonomy.Function,
+				Layer:      tool.Taxonomy.Layer,
+				Domain:     tool.Taxonomy.Domain,
+				Audience:   tool.Taxonomy.Audience,
+				Technology: tool.Taxonomy.Technology,
+			}
+		}
+
 		if tool.Commands.Run != "" {
 			d.Command = &brief.Command{
 				Run:          tool.Commands.Run,

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -64,6 +64,39 @@ func TestRubyTools(t *testing.T) {
 	assertToolDetected(t, r, "lint", "RuboCop")
 }
 
+func TestRubyTaxonomyPassesThrough(t *testing.T) {
+	r := rubyReport(t)
+
+	// Rails has [taxonomy] populated, should appear on the Detection.
+	var rails *brief.Detection
+	for i, d := range r.Tools["build"] {
+		if d.Name == "Rails" {
+			rails = &r.Tools["build"][i]
+		}
+	}
+	if rails == nil {
+		t.Fatal("expected Rails in build tools")
+	}
+	if rails.Taxonomy == nil {
+		t.Fatal("expected Rails detection to carry taxonomy")
+	}
+	if len(rails.Taxonomy.Role) == 0 || rails.Taxonomy.Role[0] != "framework" {
+		t.Errorf("Rails taxonomy.role = %v, want [framework]", rails.Taxonomy.Role)
+	}
+	if len(rails.Taxonomy.Layer) == 0 {
+		t.Error("Rails taxonomy.layer should be populated")
+	}
+
+	// RuboCop has no [taxonomy], should be nil not empty struct.
+	for _, d := range r.Tools["lint"] {
+		if d.Name == "RuboCop" {
+			if d.Taxonomy != nil {
+				t.Errorf("RuboCop has no taxonomy in KB but Detection.Taxonomy = %+v", d.Taxonomy)
+			}
+		}
+	}
+}
+
 func TestRubyScripts(t *testing.T) {
 	r := rubyReport(t)
 	if len(r.Scripts) == 0 {

--- a/kb/kb.go
+++ b/kb/kb.go
@@ -13,11 +13,13 @@ import (
 
 // ToolDef is the parsed representation of a tool TOML file.
 type ToolDef struct {
-	Tool     ToolInfo    `toml:"tool"`
-	Detect   DetectInfo  `toml:"detect"`
-	Commands CommandInfo `toml:"commands"`
-	Config   ConfigInfo  `toml:"config"`
-	Source   string      `toml:"-"` // filesystem path this was loaded from
+	Tool     ToolInfo     `toml:"tool"`
+	Detect   DetectInfo   `toml:"detect"`
+	Commands CommandInfo  `toml:"commands"`
+	Config   ConfigInfo   `toml:"config"`
+	Taxonomy Taxonomy     `toml:"taxonomy"`
+	Security SecurityInfo `toml:"security"`
+	Source   string       `toml:"-"` // filesystem path this was loaded from
 }
 
 // ToolInfo holds metadata about a tool.
@@ -51,6 +53,78 @@ type CommandInfo struct {
 type ConfigInfo struct {
 	Files    []string `toml:"files"`
 	Lockfile string   `toml:"lockfile"`
+}
+
+// Taxonomy holds oss-taxonomy facet classifications for a tool.
+// Term values are kebab-case IDs from github.com/ecosyste-ms/oss-taxonomy.
+type Taxonomy struct {
+	Role       []string `toml:"role"`
+	Function   []string `toml:"function"`
+	Layer      []string `toml:"layer"`
+	Domain     []string `toml:"domain"`
+	Audience   []string `toml:"audience"`
+	Technology []string `toml:"technology"`
+}
+
+// Empty reports whether all facets are unset.
+func (t Taxonomy) Empty() bool {
+	return len(t.Role) == 0 && len(t.Function) == 0 && len(t.Layer) == 0 &&
+		len(t.Domain) == 0 && len(t.Audience) == 0 && len(t.Technology) == 0
+}
+
+// Tags returns all facet values as facet:term strings, e.g. "role:framework".
+// Used for matching against threat mappings.
+func (t Taxonomy) Tags() []string {
+	var tags []string
+	for _, v := range t.Role {
+		tags = append(tags, "role:"+v)
+	}
+	for _, v := range t.Function {
+		tags = append(tags, "function:"+v)
+	}
+	for _, v := range t.Layer {
+		tags = append(tags, "layer:"+v)
+	}
+	for _, v := range t.Domain {
+		tags = append(tags, "domain:"+v)
+	}
+	for _, v := range t.Audience {
+		tags = append(tags, "audience:"+v)
+	}
+	for _, v := range t.Technology {
+		tags = append(tags, "technology:"+v)
+	}
+	return tags
+}
+
+// SecurityInfo holds security-relevant data for a tool.
+type SecurityInfo struct {
+	Threats []string `toml:"threats"` // explicit threat IDs beyond what taxonomy implies
+	Sinks   []Sink   `toml:"sinks"`
+}
+
+// Sink is a known dangerous function or method in a tool.
+type Sink struct {
+	Symbol string `toml:"symbol"` // method/function name, e.g. "html_safe"
+	Threat string `toml:"threat"` // threat ID from _threats.toml registry
+	CWE    string `toml:"cwe"`    // optional, defaults from threat registry
+	Note   string `toml:"note"`
+}
+
+// ThreatDef is a threat ID registered in _threats.toml.
+type ThreatDef struct {
+	ID    string `toml:"id"`
+	CWE   string `toml:"cwe"`
+	OWASP string `toml:"owasp"`
+	Title string `toml:"title"`
+}
+
+// ThreatMapping maps a set of taxonomy tags to threat IDs.
+// Match is conjunctive: a tool must carry all listed tags to trigger.
+type ThreatMapping struct {
+	Match   []string `toml:"match"`   // facet:term tags, all must be present
+	Threats []string `toml:"threats"` // threat IDs that apply when matched
+	Note    string   `toml:"note"`
 }
 
 // ScriptSourceDef defines how to extract scripts from a project file.
@@ -148,17 +222,19 @@ type ManifestInfo struct {
 
 // KnowledgeBase holds all loaded definitions.
 type KnowledgeBase struct {
-	Tools         []*ToolDef
-	ByName        map[string]*ToolDef
-	ByCategory    map[string][]*ToolDef
-	Ecosystems    map[string][]*ToolDef
-	ScriptSources []ScriptSourceDef
-	Resources     []ResourceDef
-	Layouts       *LayoutDef
-	StyleConfig   *StyleConfigDef
-	Runtimes      []RuntimeVersionDef
-	ManifestFiles []string
-	CIConfig      *CIConfigDef
+	Tools          []*ToolDef
+	ByName         map[string]*ToolDef
+	ByCategory     map[string][]*ToolDef
+	Ecosystems     map[string][]*ToolDef
+	ScriptSources  []ScriptSourceDef
+	Resources      []ResourceDef
+	Layouts        *LayoutDef
+	StyleConfig    *StyleConfigDef
+	Runtimes       []RuntimeVersionDef
+	ManifestFiles  []string
+	CIConfig       *CIConfigDef
+	Threats        map[string]ThreatDef // threat ID -> definition
+	ThreatMappings []ThreatMapping
 }
 
 // Load reads all TOML files from the embedded filesystem and returns a KnowledgeBase.
@@ -167,6 +243,7 @@ func Load(fsys embed.FS) (*KnowledgeBase, error) {
 		ByName:     make(map[string]*ToolDef),
 		ByCategory: make(map[string][]*ToolDef),
 		Ecosystems: make(map[string][]*ToolDef),
+		Threats:    make(map[string]ThreatDef),
 	}
 
 	err := fs.WalkDir(fsys, "knowledge", func(path string, d fs.DirEntry, err error) error {
@@ -201,12 +278,18 @@ func Load(fsys embed.FS) (*KnowledgeBase, error) {
 			return base.loadManifests(data, path)
 		case name == "_ci.toml":
 			return base.loadCIConfig(data, path)
+		case name == "_threats.toml":
+			return base.loadThreats(data, path)
 		default:
 			return base.loadTool(data, path)
 		}
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	if err := base.Validate(); err != nil {
+		return nil, fmt.Errorf("knowledge base validation: %w", err)
 	}
 
 	return base, nil
@@ -305,6 +388,49 @@ func (base *KnowledgeBase) loadCIConfig(data []byte, path string) error {
 		return fmt.Errorf("parsing %s: %w", path, err)
 	}
 	base.CIConfig = &def
+	return nil
+}
+
+func (base *KnowledgeBase) loadThreats(data []byte, path string) error {
+	var wrapper struct {
+		Threats  []ThreatDef     `toml:"threats"`
+		Mappings []ThreatMapping `toml:"mappings"`
+	}
+	if err := toml.Unmarshal(data, &wrapper); err != nil {
+		return fmt.Errorf("parsing %s: %w", path, err)
+	}
+	for _, t := range wrapper.Threats {
+		if _, dup := base.Threats[t.ID]; dup {
+			return fmt.Errorf("%s: duplicate threat id %q", path, t.ID)
+		}
+		base.Threats[t.ID] = t
+	}
+	base.ThreatMappings = append(base.ThreatMappings, wrapper.Mappings...)
+	return nil
+}
+
+// Validate checks cross-references in the loaded knowledge base.
+// Called after Load to verify threat IDs in mappings and sinks resolve.
+func (base *KnowledgeBase) Validate() error {
+	for _, m := range base.ThreatMappings {
+		for _, id := range m.Threats {
+			if _, ok := base.Threats[id]; !ok {
+				return fmt.Errorf("threat mapping %v references unknown threat id %q", m.Match, id)
+			}
+		}
+	}
+	for _, tool := range base.Tools {
+		for _, id := range tool.Security.Threats {
+			if _, ok := base.Threats[id]; !ok {
+				return fmt.Errorf("%s: [security].threats references unknown threat id %q", tool.Source, id)
+			}
+		}
+		for _, sink := range tool.Security.Sinks {
+			if _, ok := base.Threats[sink.Threat]; !ok {
+				return fmt.Errorf("%s: sink %q references unknown threat id %q", tool.Source, sink.Symbol, sink.Threat)
+			}
+		}
+	}
 	return nil
 }
 

--- a/kb/kb_test.go
+++ b/kb/kb_test.go
@@ -1,0 +1,198 @@
+package kb_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/git-pkgs/brief"
+	"github.com/git-pkgs/brief/kb"
+)
+
+func loadKB(t *testing.T) *kb.KnowledgeBase {
+	t.Helper()
+	base, err := kb.Load(brief.KnowledgeFS)
+	if err != nil {
+		t.Fatalf("loading knowledge base: %v", err)
+	}
+	return base
+}
+
+func TestThreatsRegistryLoads(t *testing.T) {
+	base := loadKB(t)
+	if len(base.Threats) == 0 {
+		t.Fatal("expected threats registry to be populated from _threats.toml")
+	}
+
+	want := []string{"sql_injection", "xss", "command_injection", "deserialization", "ssrf"}
+	for _, id := range want {
+		def, ok := base.Threats[id]
+		if !ok {
+			t.Errorf("expected threat %q in registry", id)
+			continue
+		}
+		if def.CWE == "" {
+			t.Errorf("threat %q has no CWE", id)
+		}
+		if def.Title == "" {
+			t.Errorf("threat %q has no title", id)
+		}
+	}
+}
+
+func TestThreatMappingsLoad(t *testing.T) {
+	base := loadKB(t)
+	if len(base.ThreatMappings) == 0 {
+		t.Fatal("expected threat mappings to be populated")
+	}
+
+	// Find the templating mapping and check its shape.
+	var found bool
+	for _, m := range base.ThreatMappings {
+		if len(m.Match) == 1 && m.Match[0] == "function:templating" {
+			found = true
+			if !slices.Contains(m.Threats, "xss") {
+				t.Errorf("templating mapping should include xss, got %v", m.Threats)
+			}
+			if !slices.Contains(m.Threats, "ssti") {
+				t.Errorf("templating mapping should include ssti, got %v", m.Threats)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected function:templating mapping")
+	}
+}
+
+func TestValidate(t *testing.T) {
+	base := loadKB(t)
+	if err := base.Validate(); err != nil {
+		t.Fatalf("knowledge base failed validation: %v", err)
+	}
+}
+
+func TestValidateRejectsUnknownMappingThreat(t *testing.T) {
+	base := &kb.KnowledgeBase{
+		Threats: map[string]kb.ThreatDef{
+			"xss": {ID: "xss", CWE: "CWE-79", Title: "XSS"},
+		},
+		ThreatMappings: []kb.ThreatMapping{
+			{Match: []string{"function:templating"}, Threats: []string{"xss", "nonexistent"}},
+		},
+	}
+	err := base.Validate()
+	if err == nil {
+		t.Fatal("expected validation error for unknown threat in mapping")
+	}
+}
+
+func TestValidateRejectsUnknownSinkThreat(t *testing.T) {
+	base := &kb.KnowledgeBase{
+		Threats: map[string]kb.ThreatDef{
+			"xss": {ID: "xss", CWE: "CWE-79", Title: "XSS"},
+		},
+		Tools: []*kb.ToolDef{
+			{
+				Tool:   kb.ToolInfo{Name: "Fake"},
+				Source: "fake.toml",
+				Security: kb.SecurityInfo{
+					Sinks: []kb.Sink{
+						{Symbol: "eval", Threat: "nonexistent"},
+					},
+				},
+			},
+		},
+	}
+	err := base.Validate()
+	if err == nil {
+		t.Fatal("expected validation error for unknown threat in sink")
+	}
+}
+
+func TestValidateRejectsUnknownExplicitThreat(t *testing.T) {
+	base := &kb.KnowledgeBase{
+		Threats: map[string]kb.ThreatDef{},
+		Tools: []*kb.ToolDef{
+			{
+				Tool:     kb.ToolInfo{Name: "Fake"},
+				Source:   "fake.toml",
+				Security: kb.SecurityInfo{Threats: []string{"nonexistent"}},
+			},
+		},
+	}
+	err := base.Validate()
+	if err == nil {
+		t.Fatal("expected validation error for unknown explicit threat")
+	}
+}
+
+func TestTaxonomyEmpty(t *testing.T) {
+	var empty kb.Taxonomy
+	if !empty.Empty() {
+		t.Error("zero-value Taxonomy should be Empty()")
+	}
+
+	populated := kb.Taxonomy{Role: []string{"framework"}}
+	if populated.Empty() {
+		t.Error("Taxonomy with role should not be Empty()")
+	}
+}
+
+func TestTaxonomyTags(t *testing.T) {
+	tax := kb.Taxonomy{
+		Role:     []string{"framework"},
+		Function: []string{"templating", "authentication"},
+		Layer:    []string{"backend"},
+	}
+	tags := tax.Tags()
+
+	want := []string{"role:framework", "function:templating", "function:authentication", "layer:backend"}
+	if len(tags) != len(want) {
+		t.Fatalf("expected %d tags, got %d: %v", len(want), len(tags), tags)
+	}
+	for _, w := range want {
+		if !slices.Contains(tags, w) {
+			t.Errorf("expected tag %q in %v", w, tags)
+		}
+	}
+}
+
+func TestRailsHasTaxonomy(t *testing.T) {
+	base := loadKB(t)
+	rails := base.ByName["Rails"]
+	if rails == nil {
+		t.Fatal("Rails not found in KB")
+	}
+	if rails.Taxonomy.Empty() {
+		t.Fatal("Rails should have taxonomy populated")
+	}
+	if !slices.Contains(rails.Taxonomy.Role, "framework") {
+		t.Errorf("Rails role should include framework, got %v", rails.Taxonomy.Role)
+	}
+	if !slices.Contains(rails.Taxonomy.Layer, "backend") {
+		t.Errorf("Rails layer should include backend, got %v", rails.Taxonomy.Layer)
+	}
+}
+
+func TestRubyHasSinks(t *testing.T) {
+	base := loadKB(t)
+	ruby := base.ByName["Ruby"]
+	if ruby == nil {
+		t.Fatal("Ruby not found in KB")
+	}
+	if len(ruby.Security.Sinks) == 0 {
+		t.Fatal("Ruby should have sinks populated")
+	}
+
+	var foundEval bool
+	for _, s := range ruby.Security.Sinks {
+		if s.Symbol == "eval" {
+			foundEval = true
+			if s.Threat != "code_injection" {
+				t.Errorf("eval sink threat = %q, want code_injection", s.Threat)
+			}
+		}
+	}
+	if !foundEval {
+		t.Error("expected eval sink on Ruby")
+	}
+}

--- a/knowledge/_shared/_threats.toml
+++ b/knowledge/_shared/_threats.toml
@@ -1,0 +1,189 @@
+# Threat ID registry for brief threat-model.
+# IDs are short names cross-referenced to CWE and OWASP Top 10 2021.
+
+[[threats]]
+id = "sql_injection"
+cwe = "CWE-89"
+owasp = "A03:2021"
+title = "SQL Injection"
+
+[[threats]]
+id = "xss"
+cwe = "CWE-79"
+owasp = "A03:2021"
+title = "Cross-Site Scripting"
+
+[[threats]]
+id = "command_injection"
+cwe = "CWE-78"
+owasp = "A03:2021"
+title = "OS Command Injection"
+
+[[threats]]
+id = "code_injection"
+cwe = "CWE-94"
+owasp = "A03:2021"
+title = "Code Injection"
+
+[[threats]]
+id = "deserialization"
+cwe = "CWE-502"
+owasp = "A08:2021"
+title = "Insecure Deserialization"
+
+[[threats]]
+id = "ssrf"
+cwe = "CWE-918"
+owasp = "A10:2021"
+title = "Server-Side Request Forgery"
+
+[[threats]]
+id = "path_traversal"
+cwe = "CWE-22"
+owasp = "A01:2021"
+title = "Path Traversal"
+
+[[threats]]
+id = "mass_assignment"
+cwe = "CWE-915"
+owasp = "A08:2021"
+title = "Mass Assignment"
+
+[[threats]]
+id = "ssti"
+cwe = "CWE-1336"
+owasp = "A03:2021"
+title = "Server-Side Template Injection"
+
+[[threats]]
+id = "open_redirect"
+cwe = "CWE-601"
+owasp = "A01:2021"
+title = "Open Redirect"
+
+[[threats]]
+id = "xxe"
+cwe = "CWE-611"
+owasp = "A05:2021"
+title = "XML External Entity"
+
+[[threats]]
+id = "csrf"
+cwe = "CWE-352"
+owasp = "A01:2021"
+title = "Cross-Site Request Forgery"
+
+[[threats]]
+id = "auth_bypass"
+cwe = "CWE-287"
+owasp = "A07:2021"
+title = "Authentication Bypass"
+
+[[threats]]
+id = "session_fixation"
+cwe = "CWE-384"
+owasp = "A07:2021"
+title = "Session Fixation"
+
+[[threats]]
+id = "weak_crypto"
+cwe = "CWE-327"
+owasp = "A02:2021"
+title = "Weak Cryptography"
+
+[[threats]]
+id = "secret_exposure"
+cwe = "CWE-200"
+owasp = "A02:2021"
+title = "Secret Exposure"
+
+[[threats]]
+id = "dos"
+cwe = "CWE-400"
+title = "Denial of Service"
+
+[[threats]]
+id = "nosql_injection"
+cwe = "CWE-943"
+owasp = "A03:2021"
+title = "NoSQL Injection"
+
+[[threats]]
+id = "ldap_injection"
+cwe = "CWE-90"
+owasp = "A03:2021"
+title = "LDAP Injection"
+
+[[threats]]
+id = "unsafe_reflection"
+cwe = "CWE-470"
+owasp = "A03:2021"
+title = "Unsafe Reflection"
+
+# Mappings from oss-taxonomy facet:term tags to threat IDs.
+# match is conjunctive: a tool must carry all listed tags to trigger the mapping.
+
+[[mappings]]
+match = ["function:templating"]
+threats = ["xss", "ssti"]
+note = "Renders data into output, escaping is bypassable"
+
+[[mappings]]
+match = ["function:serialization"]
+threats = ["deserialization"]
+note = "Deserializes data into objects, may instantiate arbitrary types"
+
+[[mappings]]
+match = ["function:parsing"]
+threats = ["xxe", "dos"]
+note = "Parsers for XML/YAML may resolve external entities or have quadratic blowup"
+
+[[mappings]]
+match = ["function:encryption"]
+threats = ["weak_crypto"]
+note = "Crypto primitives can be misconfigured or use deprecated algorithms"
+
+[[mappings]]
+match = ["function:file-management"]
+threats = ["path_traversal"]
+note = "File operations with caller-controlled paths"
+
+[[mappings]]
+match = ["function:scraping"]
+threats = ["ssrf"]
+note = "Fetches caller-controlled URLs"
+
+[[mappings]]
+match = ["function:http-client"]
+threats = ["ssrf"]
+note = "Outbound HTTP with caller-controlled URLs"
+
+[[mappings]]
+match = ["function:authentication"]
+threats = ["auth_bypass", "session_fixation"]
+note = "Identity and session handling"
+
+[[mappings]]
+match = ["function:data-mapping"]
+threats = ["sql_injection", "mass_assignment"]
+note = "Constructs database queries, often with raw escape hatches"
+
+[[mappings]]
+match = ["function:secrets-management"]
+threats = ["secret_exposure"]
+note = "Loads credentials into process environment"
+
+[[mappings]]
+match = ["function:process-execution"]
+threats = ["command_injection"]
+note = "Spawns OS processes from string arguments"
+
+[[mappings]]
+match = ["role:framework", "layer:backend"]
+threats = ["xss", "csrf", "open_redirect", "ssrf", "path_traversal", "auth_bypass"]
+note = "Server-side framework handling user-controlled HTTP input"
+
+[[mappings]]
+match = ["role:framework", "layer:frontend"]
+threats = ["xss", "open_redirect"]
+note = "Client-side framework rendering user-controlled data"

--- a/knowledge/ruby/language.toml
+++ b/knowledge/ruby/language.toml
@@ -9,3 +9,26 @@ description = "Dynamic, object-oriented programming language"
 [detect]
 files = ["Gemfile", "Rakefile", "*.rb", "**/*.rb", "*.gemspec"]
 ecosystems = ["ruby"]
+
+[taxonomy]
+role = ["language"]
+
+[[security.sinks]]
+symbol = "eval"
+threat = "code_injection"
+cwe = "CWE-95"
+
+[[security.sinks]]
+symbol = "system"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "send"
+threat = "unsafe_reflection"
+cwe = "CWE-470"
+
+[[security.sinks]]
+symbol = "Marshal.load"
+threat = "deserialization"
+cwe = "CWE-502"

--- a/knowledge/ruby/rails.toml
+++ b/knowledge/ruby/rails.toml
@@ -17,3 +17,9 @@ alternatives = ["bin/rails server"]
 
 [config]
 files = ["config/routes.rb", "config/application.rb", "config/environments/"]
+
+[taxonomy]
+role = ["framework"]
+function = ["api-development", "templating", "authentication"]
+layer = ["backend", "full-stack"]
+domain = ["web-development"]


### PR DESCRIPTION
Tool definitions can now carry oss-taxonomy facet tags and security data. A new `_threats.toml` shared config holds the threat ID registry with CWE/OWASP cross-references and the facet-tag → threat mappings.

`kb.go` gains `Taxonomy` (six string-slice facets with `Empty()` and `Tags()` helpers), `SecurityInfo`, `Sink`, `ThreatDef`, `ThreatMapping`. `Load()` now calls `Validate()` before returning so dangling threat references in mappings or sinks fail at build time. `brief.go` gains the output types (`ThreatReport`, `SinkReport`, etc) and a `Taxonomy` pointer on `Detection` that passes through when populated.

Seeded `rails.toml` with `[taxonomy]` and `ruby/language.toml` with four sinks so tests have real data. Running `brief testdata/ruby-project --json` shows the taxonomy on the Rails detection.

Closes #13