### PR TITLE
Add brief threat-model and brief sinks commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Or download a binary from [releases](https://github.com/git-pkgs/brief/releases)
 brief [flags] [path | url]        Detect project toolchain
 brief diff [flags] [ref1] [ref2]  Detect only what changed between refs
 brief missing [flags] [path]      Show recommended tooling gaps
+brief threat-model [flags] [path] Threat categories implied by detected stack
+brief sinks [flags] [path]        Dangerous functions in detected tools
 brief enrich [flags] [path]       Detect and enrich with external data
 brief list tools                  All tools in the knowledge base
 brief list ecosystems             Supported ecosystems

--- a/cmd/brief/main.go
+++ b/cmd/brief/main.go
@@ -45,6 +45,12 @@ func main() {
 		case "missing":
 			cmdMissing(os.Args[2:])
 			return
+		case "threat-model":
+			cmdThreatModel(os.Args[2:])
+			return
+		case "sinks":
+			cmdSinks(os.Args[2:])
+			return
 		}
 	}
 

--- a/cmd/brief/missing.go
+++ b/cmd/brief/missing.go
@@ -1,58 +1,20 @@
 package main
 
 import (
-	"flag"
-	"fmt"
 	"os"
-	"strings"
 
-	"github.com/git-pkgs/brief"
-	"github.com/git-pkgs/brief/detect"
-	"github.com/git-pkgs/brief/kb"
 	"github.com/git-pkgs/brief/report"
 )
 
 func cmdMissing(args []string) {
-	fs := flag.NewFlagSet("brief missing", flag.ExitOnError)
-	jsonFlag := fs.Bool("json", false, "Force JSON output")
-	humanFlag := fs.Bool("human", false, "Force human-readable output")
-	markdownFlag := fs.Bool("markdown", false, "Force markdown output")
-	scanDepth := fs.Int("scan-depth", 0, "Max directory depth for language detection (default 4)")
-	skip := fs.String("skip", "", "Additional directories to skip, comma-separated")
-	_ = fs.Parse(args)
-
-	path := "."
-	if fs.NArg() > 0 {
-		path = fs.Arg(0)
-	}
-
-	knowledgeBase, err := kb.Load(brief.KnowledgeFS)
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "error loading knowledge base: %v\n", err)
-		os.Exit(1)
-	}
-
-	engine := detect.New(knowledgeBase, path)
-	engine.ScanDepth = *scanDepth
-	if *skip != "" {
-		engine.SkipDirs = strings.Split(*skip, ",")
-	}
-	r, err := engine.Run()
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
-	}
-
+	engine, r, format := runDetection("missing", args)
 	mr := engine.Missing(r)
 
-	switch {
-	case *markdownFlag:
+	switch format {
+	case formatMarkdown:
 		report.MissingMarkdown(os.Stdout, mr)
-	case *jsonFlag || (!*humanFlag && !isTTY()):
-		if err := report.MissingJSON(os.Stdout, mr); err != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "error writing JSON: %v\n", err)
-			os.Exit(1)
-		}
+	case formatJSON:
+		writeJSONOrExit(report.MissingJSON(os.Stdout, mr))
 	default:
 		report.MissingHuman(os.Stdout, mr)
 	}

--- a/cmd/brief/threat.go
+++ b/cmd/brief/threat.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/git-pkgs/brief"
+	"github.com/git-pkgs/brief/detect"
+	"github.com/git-pkgs/brief/kb"
+	"github.com/git-pkgs/brief/report"
+)
+
+// outputFormat is the resolved output mode after flag parsing.
+type outputFormat int
+
+const (
+	formatJSON outputFormat = iota
+	formatHuman
+	formatMarkdown
+)
+
+// runDetection handles the common preamble for subcommands that run detection
+// and post-process the report: standard flags, KB load, engine setup, run.
+// Exits on error. Returns the engine (for post-processors), the report,
+// and the resolved output format.
+func runDetection(name string, args []string) (*detect.Engine, *brief.Report, outputFormat) {
+	fs := flag.NewFlagSet("brief "+name, flag.ExitOnError)
+	jsonFlag := fs.Bool("json", false, "Force JSON output")
+	humanFlag := fs.Bool("human", false, "Force human-readable output")
+	markdownFlag := fs.Bool("markdown", false, "Force markdown output")
+	scanDepth := fs.Int("scan-depth", 0, "Max directory depth for language detection (default 4)")
+	skip := fs.String("skip", "", "Additional directories to skip, comma-separated")
+	_ = fs.Parse(args)
+
+	path := "."
+	if fs.NArg() > 0 {
+		path = fs.Arg(0)
+	}
+
+	knowledgeBase, err := kb.Load(brief.KnowledgeFS)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "error loading knowledge base: %v\n", err)
+		os.Exit(1)
+	}
+
+	engine := detect.New(knowledgeBase, path)
+	engine.ScanDepth = *scanDepth
+	if *skip != "" {
+		engine.SkipDirs = strings.Split(*skip, ",")
+	}
+	r, err := engine.Run()
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	format := formatHuman
+	switch {
+	case *markdownFlag:
+		format = formatMarkdown
+	case *jsonFlag || (!*humanFlag && !isTTY()):
+		format = formatJSON
+	}
+
+	return engine, r, format
+}
+
+func writeJSONOrExit(err error) {
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "error writing JSON: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func cmdThreatModel(args []string) {
+	engine, r, format := runDetection("threat-model", args)
+	tr := engine.ThreatModel(r)
+
+	switch format {
+	case formatMarkdown:
+		report.ThreatMarkdown(os.Stdout, tr)
+	case formatJSON:
+		writeJSONOrExit(report.ThreatJSON(os.Stdout, tr))
+	default:
+		report.ThreatHuman(os.Stdout, tr)
+	}
+}
+
+func cmdSinks(args []string) {
+	engine, r, format := runDetection("sinks", args)
+	sr := engine.Sinks(r)
+
+	switch format {
+	case formatMarkdown:
+		report.SinksMarkdown(os.Stdout, sr)
+	case formatJSON:
+		writeJSONOrExit(report.SinksJSON(os.Stdout, sr))
+	default:
+		report.SinksHuman(os.Stdout, sr)
+	}
+}

--- a/detect/threat.go
+++ b/detect/threat.go
@@ -1,0 +1,178 @@
+package detect
+
+import (
+	"sort"
+
+	"github.com/git-pkgs/brief"
+)
+
+// ThreatModel resolves the threat surface implied by detected tools.
+// Each tool's taxonomy tags are matched against the threat mappings in
+// _threats.toml; matched threat IDs are unioned with any explicit
+// [security].threats on the tool, then resolved against the registry.
+func (e *Engine) ThreatModel(r *brief.Report) *brief.ThreatReport {
+	tr := &brief.ThreatReport{
+		Version: brief.Version,
+		Path:    r.Path,
+	}
+
+	for eco := range e.detectedEcosystems {
+		tr.Ecosystems = append(tr.Ecosystems, eco)
+	}
+	sort.Strings(tr.Ecosystems)
+
+	// threat ID -> set of tool names that introduced it
+	introducedBy := make(map[string]map[string]bool)
+	// threat ID -> first matching mapping note (for context in output)
+	notes := make(map[string]string)
+
+	addThreat := func(id, tool, note string) {
+		if introducedBy[id] == nil {
+			introducedBy[id] = make(map[string]bool)
+		}
+		introducedBy[id][tool] = true
+		if notes[id] == "" && note != "" {
+			notes[id] = note
+		}
+	}
+
+	for _, d := range allDetections(r) {
+		tool := e.KB.ByName[d.Name]
+		if tool == nil {
+			continue
+		}
+
+		// Build the tool's tag set for conjunctive matching.
+		tags := make(map[string]bool)
+		for _, t := range tool.Taxonomy.Tags() {
+			tags[t] = true
+		}
+
+		// Skip stack entry if the tool has no taxonomy and no security data:
+		// it contributes nothing and would just be noise.
+		hasSecurityData := len(tool.Security.Threats) > 0 || len(tool.Security.Sinks) > 0
+		if len(tags) > 0 || hasSecurityData {
+			tr.Stack = append(tr.Stack, brief.StackEntry{
+				Name:     d.Name,
+				Taxonomy: d.Taxonomy,
+			})
+		}
+
+		// Check each mapping for a conjunctive match against this tool's tags.
+		for _, m := range e.KB.ThreatMappings {
+			if matchesAll(tags, m.Match) {
+				for _, id := range m.Threats {
+					addThreat(id, d.Name, m.Note)
+				}
+			}
+		}
+
+		// Explicit threats on the tool definition.
+		for _, id := range tool.Security.Threats {
+			addThreat(id, d.Name, "")
+		}
+	}
+
+	// Resolve threat IDs against the registry and sort.
+	ids := make([]string, 0, len(introducedBy))
+	for id := range introducedBy {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	for _, id := range ids {
+		def := e.KB.Threats[id]
+		introducers := make([]string, 0, len(introducedBy[id]))
+		for name := range introducedBy[id] {
+			introducers = append(introducers, name)
+		}
+		sort.Strings(introducers)
+
+		tr.Threats = append(tr.Threats, brief.Threat{
+			ID:           id,
+			CWE:          def.CWE,
+			OWASP:        def.OWASP,
+			Title:        def.Title,
+			IntroducedBy: introducers,
+			Note:         notes[id],
+		})
+	}
+
+	sort.Slice(tr.Stack, func(i, j int) bool {
+		return tr.Stack[i].Name < tr.Stack[j].Name
+	})
+
+	return tr
+}
+
+// Sinks collects known dangerous functions from all detected tools.
+// CWE is filled from the threat registry when the sink doesn't carry one.
+func (e *Engine) Sinks(r *brief.Report) *brief.SinkReport {
+	sr := &brief.SinkReport{
+		Version: brief.Version,
+		Path:    r.Path,
+	}
+
+	for _, d := range allDetections(r) {
+		tool := e.KB.ByName[d.Name]
+		if tool == nil {
+			continue
+		}
+		for _, s := range tool.Security.Sinks {
+			cwe := s.CWE
+			if cwe == "" {
+				cwe = e.KB.Threats[s.Threat].CWE
+			}
+			sr.Sinks = append(sr.Sinks, brief.SinkEntry{
+				Symbol: s.Symbol,
+				Tool:   d.Name,
+				Threat: s.Threat,
+				CWE:    cwe,
+				Note:   s.Note,
+			})
+		}
+	}
+
+	sort.Slice(sr.Sinks, func(i, j int) bool {
+		if sr.Sinks[i].Tool != sr.Sinks[j].Tool {
+			return sr.Sinks[i].Tool < sr.Sinks[j].Tool
+		}
+		return sr.Sinks[i].Symbol < sr.Sinks[j].Symbol
+	})
+
+	return sr
+}
+
+// allDetections flattens languages, package managers, and tools into one slice.
+func allDetections(r *brief.Report) []brief.Detection {
+	var all []brief.Detection
+	all = append(all, r.Languages...)
+	all = append(all, r.PackageManagers...)
+	for _, cat := range sortedKeys(r.Tools) {
+		all = append(all, r.Tools[cat]...)
+	}
+	return all
+}
+
+// matchesAll reports whether the tag set contains every required tag.
+// An empty required slice matches nothing (vacuous mappings shouldn't fire).
+func matchesAll(have map[string]bool, required []string) bool {
+	if len(required) == 0 {
+		return false
+	}
+	for _, r := range required {
+		if !have[r] {
+			return false
+		}
+	}
+	return true
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/detect/threat_test.go
+++ b/detect/threat_test.go
@@ -1,0 +1,380 @@
+package detect
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/git-pkgs/brief"
+	"github.com/git-pkgs/brief/kb"
+)
+
+// syntheticEngine builds an Engine wrapping a hand-constructed KB,
+// for tests that don't want to load the full embedded knowledge base.
+func syntheticEngine(base *kb.KnowledgeBase) *Engine {
+	return &Engine{
+		KB:                 base,
+		detectedEcosystems: make(map[string]bool),
+	}
+}
+
+func TestThreatModelRubyProject(t *testing.T) {
+	engine := New(loadKB(t), "../testdata/ruby-project")
+	r, err := engine.Run()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tr := engine.ThreatModel(r)
+
+	if tr.Path != r.Path {
+		t.Errorf("Path = %q, want %q", tr.Path, r.Path)
+	}
+	if !slices.Contains(tr.Ecosystems, "ruby") {
+		t.Errorf("expected ruby in ecosystems, got %v", tr.Ecosystems)
+	}
+
+	// Rails has role:framework + layer:backend, which fires the backend-framework mapping.
+	// That mapping includes xss, csrf, open_redirect, ssrf, path_traversal, auth_bypass.
+	// Rails also has function:templating which fires xss + ssti.
+	// Rails also has function:authentication which fires auth_bypass + session_fixation.
+	threatIDs := make(map[string]bool)
+	for _, th := range tr.Threats {
+		threatIDs[th.ID] = true
+	}
+
+	wantThreats := []string{"xss", "csrf", "ssti", "auth_bypass", "ssrf"}
+	for _, w := range wantThreats {
+		if !threatIDs[w] {
+			t.Errorf("expected threat %q, got %v", w, tr.Threats)
+		}
+	}
+
+	// xss should be introduced by Rails (via both backend-framework and templating mappings).
+	for _, th := range tr.Threats {
+		if th.ID == "xss" {
+			if !slices.Contains(th.IntroducedBy, "Rails") {
+				t.Errorf("xss introduced_by = %v, want to include Rails", th.IntroducedBy)
+			}
+			if th.CWE != "CWE-79" {
+				t.Errorf("xss CWE = %q, want CWE-79", th.CWE)
+			}
+			if th.Title == "" {
+				t.Error("xss should have a title from the registry")
+			}
+		}
+	}
+
+	// Stack should include Rails (has taxonomy) and Ruby (has sinks)
+	// but not RuboCop (no taxonomy, no security data).
+	stackNames := make(map[string]bool)
+	for _, s := range tr.Stack {
+		stackNames[s.Name] = true
+	}
+	if !stackNames["Rails"] {
+		t.Error("expected Rails in stack")
+	}
+	if !stackNames["Ruby"] {
+		t.Error("expected Ruby in stack (has sinks)")
+	}
+	if stackNames["RuboCop"] {
+		t.Error("RuboCop has no taxonomy/security data, should not be in stack")
+	}
+}
+
+func TestThreatModelDeterministic(t *testing.T) {
+	engine := New(loadKB(t), "../testdata/ruby-project")
+	r, err := engine.Run()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tr1 := engine.ThreatModel(r)
+	tr2 := engine.ThreatModel(r)
+
+	if len(tr1.Threats) != len(tr2.Threats) {
+		t.Fatalf("threat count differs between runs: %d vs %d", len(tr1.Threats), len(tr2.Threats))
+	}
+	for i := range tr1.Threats {
+		if tr1.Threats[i].ID != tr2.Threats[i].ID {
+			t.Errorf("threat order differs at %d: %q vs %q", i, tr1.Threats[i].ID, tr2.Threats[i].ID)
+		}
+		if !slices.Equal(tr1.Threats[i].IntroducedBy, tr2.Threats[i].IntroducedBy) {
+			t.Errorf("introduced_by order differs for %q", tr1.Threats[i].ID)
+		}
+	}
+}
+
+func TestThreatModelConjunctiveMatch(t *testing.T) {
+	// A tool with role:framework but NOT layer:backend should not trigger
+	// the [role:framework, layer:backend] mapping.
+	base := &kb.KnowledgeBase{
+		ByName: map[string]*kb.ToolDef{
+			"FrontendOnly": {
+				Tool:     kb.ToolInfo{Name: "FrontendOnly"},
+				Taxonomy: kb.Taxonomy{Role: []string{"framework"}, Layer: []string{"frontend"}},
+			},
+		},
+		Threats: map[string]kb.ThreatDef{
+			"xss":           {ID: "xss", CWE: "CWE-79", Title: "XSS"},
+			"csrf":          {ID: "csrf", CWE: "CWE-352", Title: "CSRF"},
+			"open_redirect": {ID: "open_redirect", CWE: "CWE-601", Title: "Open Redirect"},
+		},
+		ThreatMappings: []kb.ThreatMapping{
+			{Match: []string{"role:framework", "layer:backend"}, Threats: []string{"csrf"}},
+			{Match: []string{"role:framework", "layer:frontend"}, Threats: []string{"xss", "open_redirect"}},
+		},
+	}
+
+	r := &brief.Report{
+		Tools: map[string][]brief.Detection{
+			"build": {{Name: "FrontendOnly"}},
+		},
+	}
+
+	tr := syntheticEngine(base).ThreatModel(r)
+
+	threatIDs := make(map[string]bool)
+	for _, th := range tr.Threats {
+		threatIDs[th.ID] = true
+	}
+
+	if threatIDs["csrf"] {
+		t.Error("csrf should not fire: tool has layer:frontend, mapping requires layer:backend")
+	}
+	if !threatIDs["xss"] {
+		t.Error("xss should fire: tool matches role:framework + layer:frontend")
+	}
+	if !threatIDs["open_redirect"] {
+		t.Error("open_redirect should fire")
+	}
+}
+
+func TestThreatModelDeduplicatesIntroducers(t *testing.T) {
+	// Two tools both introducing xss should produce one threat entry
+	// with both names in introduced_by.
+	base := &kb.KnowledgeBase{
+		ByName: map[string]*kb.ToolDef{
+			"ToolA": {
+				Tool:     kb.ToolInfo{Name: "ToolA"},
+				Taxonomy: kb.Taxonomy{Function: []string{"templating"}},
+			},
+			"ToolB": {
+				Tool:     kb.ToolInfo{Name: "ToolB"},
+				Taxonomy: kb.Taxonomy{Function: []string{"templating"}},
+			},
+		},
+		Threats: map[string]kb.ThreatDef{
+			"xss": {ID: "xss", CWE: "CWE-79", Title: "XSS"},
+		},
+		ThreatMappings: []kb.ThreatMapping{
+			{Match: []string{"function:templating"}, Threats: []string{"xss"}},
+		},
+	}
+
+	r := &brief.Report{
+		Tools: map[string][]brief.Detection{
+			"build": {{Name: "ToolA"}, {Name: "ToolB"}},
+		},
+	}
+
+	tr := syntheticEngine(base).ThreatModel(r)
+
+	if len(tr.Threats) != 1 {
+		t.Fatalf("expected 1 threat, got %d", len(tr.Threats))
+	}
+	got := tr.Threats[0].IntroducedBy
+	want := []string{"ToolA", "ToolB"}
+	if !slices.Equal(got, want) {
+		t.Errorf("introduced_by = %v, want %v", got, want)
+	}
+}
+
+func TestThreatModelExplicitThreats(t *testing.T) {
+	// A tool with no taxonomy but explicit [security].threats should still contribute.
+	base := &kb.KnowledgeBase{
+		ByName: map[string]*kb.ToolDef{
+			"Bare": {
+				Tool:     kb.ToolInfo{Name: "Bare"},
+				Security: kb.SecurityInfo{Threats: []string{"ssrf"}},
+			},
+		},
+		Threats: map[string]kb.ThreatDef{
+			"ssrf": {ID: "ssrf", CWE: "CWE-918", Title: "SSRF"},
+		},
+	}
+
+	r := &brief.Report{Languages: []brief.Detection{{Name: "Bare"}}}
+	tr := syntheticEngine(base).ThreatModel(r)
+
+	if len(tr.Threats) != 1 || tr.Threats[0].ID != "ssrf" {
+		t.Fatalf("expected ssrf threat, got %v", tr.Threats)
+	}
+}
+
+func TestThreatModelEmptyMatch(t *testing.T) {
+	// A mapping with empty match should never fire.
+	base := &kb.KnowledgeBase{
+		ByName: map[string]*kb.ToolDef{
+			"Any": {
+				Tool:     kb.ToolInfo{Name: "Any"},
+				Taxonomy: kb.Taxonomy{Role: []string{"library"}},
+			},
+		},
+		Threats: map[string]kb.ThreatDef{
+			"xss": {ID: "xss", Title: "XSS"},
+		},
+		ThreatMappings: []kb.ThreatMapping{
+			{Match: []string{}, Threats: []string{"xss"}},
+		},
+	}
+
+	r := &brief.Report{Tools: map[string][]brief.Detection{"build": {{Name: "Any"}}}}
+	tr := syntheticEngine(base).ThreatModel(r)
+
+	if len(tr.Threats) != 0 {
+		t.Errorf("empty match should fire on nothing, got %v", tr.Threats)
+	}
+}
+
+func TestThreatModelGoProjectEmpty(t *testing.T) {
+	// Go fixture has no tools with taxonomy/security data yet.
+	engine := New(loadKB(t), "../testdata/go-project")
+	r, err := engine.Run()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tr := engine.ThreatModel(r)
+	if len(tr.Threats) != 0 {
+		t.Errorf("go-project has no security data, expected 0 threats, got %d", len(tr.Threats))
+	}
+	if len(tr.Stack) != 0 {
+		t.Errorf("go-project has no taxonomy data, expected empty stack, got %v", tr.Stack)
+	}
+}
+
+func TestSinksRubyProject(t *testing.T) {
+	engine := New(loadKB(t), "../testdata/ruby-project")
+	r, err := engine.Run()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	sr := engine.Sinks(r)
+
+	if len(sr.Sinks) == 0 {
+		t.Fatal("expected sinks from Ruby language def")
+	}
+
+	// All sinks in this fixture come from Ruby (only ruby/language.toml has sinks).
+	bySymbol := make(map[string]brief.SinkEntry)
+	for _, s := range sr.Sinks {
+		if s.Tool != "Ruby" {
+			t.Errorf("unexpected sink from %q: %v", s.Tool, s)
+		}
+		bySymbol[s.Symbol] = s
+	}
+
+	if e, ok := bySymbol["eval"]; !ok {
+		t.Error("expected eval sink")
+	} else if e.Threat != "code_injection" || e.CWE != "CWE-95" {
+		t.Errorf("eval sink = %+v", e)
+	}
+
+	if _, ok := bySymbol["Marshal.load"]; !ok {
+		t.Error("expected Marshal.load sink")
+	}
+}
+
+func TestSinksFillsCWEFromRegistry(t *testing.T) {
+	base := &kb.KnowledgeBase{
+		ByName: map[string]*kb.ToolDef{
+			"Lib": {
+				Tool: kb.ToolInfo{Name: "Lib"},
+				Security: kb.SecurityInfo{
+					Sinks: []kb.Sink{
+						{Symbol: "danger", Threat: "xss"}, // no CWE on the sink
+					},
+				},
+			},
+		},
+		Threats: map[string]kb.ThreatDef{
+			"xss": {ID: "xss", CWE: "CWE-79", Title: "XSS"},
+		},
+	}
+
+	r := &brief.Report{Languages: []brief.Detection{{Name: "Lib"}}}
+	sr := syntheticEngine(base).Sinks(r)
+
+	if len(sr.Sinks) != 1 {
+		t.Fatalf("expected 1 sink, got %d", len(sr.Sinks))
+	}
+	if sr.Sinks[0].CWE != "CWE-79" {
+		t.Errorf("CWE = %q, want CWE-79 from registry", sr.Sinks[0].CWE)
+	}
+}
+
+func TestSinksSorted(t *testing.T) {
+	base := &kb.KnowledgeBase{
+		ByName: map[string]*kb.ToolDef{
+			"Zebra": {
+				Tool: kb.ToolInfo{Name: "Zebra"},
+				Security: kb.SecurityInfo{
+					Sinks: []kb.Sink{{Symbol: "exec", Threat: "x"}},
+				},
+			},
+			"Alpha": {
+				Tool: kb.ToolInfo{Name: "Alpha"},
+				Security: kb.SecurityInfo{
+					Sinks: []kb.Sink{
+						{Symbol: "zebra_method", Threat: "x"},
+						{Symbol: "alpha_method", Threat: "x"},
+					},
+				},
+			},
+		},
+		Threats: map[string]kb.ThreatDef{"x": {ID: "x"}},
+	}
+
+	r := &brief.Report{
+		Languages: []brief.Detection{{Name: "Zebra"}, {Name: "Alpha"}},
+	}
+	sr := syntheticEngine(base).Sinks(r)
+
+	if len(sr.Sinks) != 3 {
+		t.Fatalf("expected 3 sinks, got %d", len(sr.Sinks))
+	}
+	// Sorted by tool, then symbol.
+	want := []struct{ tool, symbol string }{
+		{"Alpha", "alpha_method"},
+		{"Alpha", "zebra_method"},
+		{"Zebra", "exec"},
+	}
+	for i, w := range want {
+		if sr.Sinks[i].Tool != w.tool || sr.Sinks[i].Symbol != w.symbol {
+			t.Errorf("sink[%d] = %s/%s, want %s/%s", i, sr.Sinks[i].Tool, sr.Sinks[i].Symbol, w.tool, w.symbol)
+		}
+	}
+}
+
+func TestMatchesAll(t *testing.T) {
+	have := map[string]bool{"a": true, "b": true, "c": true}
+
+	cases := []struct {
+		required []string
+		want     bool
+	}{
+		{[]string{"a"}, true},
+		{[]string{"a", "b"}, true},
+		{[]string{"a", "b", "c"}, true},
+		{[]string{"a", "x"}, false},
+		{[]string{"x"}, false},
+		{[]string{}, false}, // vacuous match disallowed
+		{nil, false},
+	}
+	for _, tc := range cases {
+		if got := matchesAll(have, tc.required); got != tc.want {
+			t.Errorf("matchesAll(%v, %v) = %v, want %v", have, tc.required, got, tc.want)
+		}
+	}
+}

--- a/report/markdown.go
+++ b/report/markdown.go
@@ -351,3 +351,36 @@ func MissingMarkdown(w io.Writer, r *brief.MissingReport) {
 		_, _ = fmt.Fprintf(w, "| %s | %s | %s | %s |\n", m.Label, suggested, cmd, docs)
 	}
 }
+
+// ThreatMarkdown writes the threat report in markdown format.
+func ThreatMarkdown(w io.Writer, r *brief.ThreatReport) {
+	if len(r.Threats) == 0 {
+		_, _ = fmt.Fprintln(w, "No security data available for detected tools.")
+		return
+	}
+
+	if len(r.Ecosystems) > 0 {
+		_, _ = fmt.Fprintf(w, "**Detected:** %s\n\n", strings.Join(r.Ecosystems, ", "))
+	}
+
+	_, _ = fmt.Fprintln(w, "| Threat | CWE | OWASP | Introduced by |")
+	_, _ = fmt.Fprintln(w, "|--------|-----|-------|---------------|")
+	for _, t := range r.Threats {
+		_, _ = fmt.Fprintf(w, "| %s | %s | %s | %s |\n",
+			t.Title, t.CWE, t.OWASP, strings.Join(t.IntroducedBy, ", "))
+	}
+}
+
+// SinksMarkdown writes the sink report in markdown format.
+func SinksMarkdown(w io.Writer, r *brief.SinkReport) {
+	if len(r.Sinks) == 0 {
+		_, _ = fmt.Fprintln(w, "No sink data available for detected tools.")
+		return
+	}
+
+	_, _ = fmt.Fprintln(w, "| Tool | Symbol | Threat | CWE |")
+	_, _ = fmt.Fprintln(w, "|------|--------|--------|-----|")
+	for _, s := range r.Sinks {
+		_, _ = fmt.Fprintf(w, "| %s | `%s` | %s | %s |\n", s.Tool, s.Symbol, s.Threat, s.CWE)
+	}
+}

--- a/report/markdown_test.go
+++ b/report/markdown_test.go
@@ -268,3 +268,65 @@ func TestMissingMarkdownEmpty(t *testing.T) {
 		t.Errorf("expected empty message\ngot:\n%s", out)
 	}
 }
+
+func TestThreatMarkdown(t *testing.T) {
+	tr := &brief.ThreatReport{
+		Ecosystems: []string{"ruby"},
+		Threats: []brief.Threat{
+			{ID: "xss", CWE: "CWE-79", OWASP: "A03:2021", Title: "Cross-Site Scripting", IntroducedBy: []string{"Rails"}},
+		},
+	}
+
+	var buf bytes.Buffer
+	ThreatMarkdown(&buf, tr)
+	out := buf.String()
+
+	checks := []string{
+		"**Detected:** ruby",
+		"| Threat | CWE | OWASP | Introduced by |",
+		"| Cross-Site Scripting | CWE-79 | A03:2021 | Rails |",
+	}
+	for _, want := range checks {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\ngot:\n%s", want, out)
+		}
+	}
+}
+
+func TestThreatMarkdownEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	ThreatMarkdown(&buf, &brief.ThreatReport{})
+	if !strings.Contains(buf.String(), "No security data available") {
+		t.Errorf("expected empty message\ngot:\n%s", buf.String())
+	}
+}
+
+func TestSinksMarkdown(t *testing.T) {
+	sr := &brief.SinkReport{
+		Sinks: []brief.SinkEntry{
+			{Symbol: "eval", Tool: "Ruby", Threat: "code_injection", CWE: "CWE-95"},
+		},
+	}
+
+	var buf bytes.Buffer
+	SinksMarkdown(&buf, sr)
+	out := buf.String()
+
+	checks := []string{
+		"| Tool | Symbol | Threat | CWE |",
+		"| Ruby | `eval` | code_injection | CWE-95 |",
+	}
+	for _, want := range checks {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\ngot:\n%s", want, out)
+		}
+	}
+}
+
+func TestSinksMarkdownEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	SinksMarkdown(&buf, &brief.SinkReport{})
+	if !strings.Contains(buf.String(), "No sink data available") {
+		t.Errorf("expected empty message\ngot:\n%s", buf.String())
+	}
+}

--- a/report/report.go
+++ b/report/report.go
@@ -352,6 +352,83 @@ func MissingJSON(w io.Writer, r *brief.MissingReport) error {
 	return enc.Encode(r)
 }
 
+// ThreatJSON writes the threat report as JSON.
+func ThreatJSON(w io.Writer, r *brief.ThreatReport) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(r)
+}
+
+// ThreatHuman writes the threat report in human-readable format.
+func ThreatHuman(w io.Writer, r *brief.ThreatReport) {
+	if len(r.Threats) == 0 {
+		_, _ = fmt.Fprintln(w, "No security data available for detected tools.")
+		return
+	}
+
+	if len(r.Ecosystems) > 0 {
+		_, _ = fmt.Fprintf(w, "Detected: %s\n", strings.Join(r.Ecosystems, ", "))
+	}
+	if len(r.Stack) > 0 {
+		names := make([]string, len(r.Stack))
+		for i, s := range r.Stack {
+			names[i] = s.Name
+		}
+		_, _ = fmt.Fprintf(w, "Stack:    %s\n", strings.Join(names, ", "))
+	}
+	_, _ = fmt.Fprintln(w)
+
+	for _, t := range r.Threats {
+		refs := t.CWE
+		if t.OWASP != "" {
+			if refs != "" {
+				refs += " "
+			}
+			refs += t.OWASP
+		}
+		_, _ = fmt.Fprintf(w, "  %-18s %s  [%s]\n", t.ID, t.Title, refs)
+		_, _ = fmt.Fprintf(w, "  %-18s via %s\n", "", strings.Join(t.IntroducedBy, ", "))
+		if t.Note != "" {
+			_, _ = fmt.Fprintf(w, "  %-18s %s\n", "", t.Note)
+		}
+		_, _ = fmt.Fprintln(w)
+	}
+}
+
+// SinksJSON writes the sink report as JSON.
+func SinksJSON(w io.Writer, r *brief.SinkReport) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(r)
+}
+
+// SinksHuman writes the sink report in human-readable format, grouped by tool.
+func SinksHuman(w io.Writer, r *brief.SinkReport) {
+	if len(r.Sinks) == 0 {
+		_, _ = fmt.Fprintln(w, "No sink data available for detected tools.")
+		return
+	}
+
+	currentTool := ""
+	for _, s := range r.Sinks {
+		if s.Tool != currentTool {
+			if currentTool != "" {
+				_, _ = fmt.Fprintln(w)
+			}
+			currentTool = s.Tool
+			_, _ = fmt.Fprintf(w, "%s:\n", s.Tool)
+		}
+		line := fmt.Sprintf("  %-24s %-20s", s.Symbol, s.Threat)
+		if s.CWE != "" {
+			line += " " + s.CWE
+		}
+		_, _ = fmt.Fprintln(w, line)
+		if s.Note != "" {
+			_, _ = fmt.Fprintf(w, "  %-24s %s\n", "", s.Note)
+		}
+	}
+}
+
 // MissingHuman writes the missing report in human-readable format.
 func MissingHuman(w io.Writer, r *brief.MissingReport) {
 	if len(r.Missing) == 0 {

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -198,3 +198,133 @@ func TestJoinDirs(t *testing.T) {
 		}
 	}
 }
+
+func sampleThreatReport() *brief.ThreatReport {
+	return &brief.ThreatReport{
+		Ecosystems: []string{"ruby"},
+		Stack: []brief.StackEntry{
+			{Name: "Rails"},
+			{Name: "Ruby"},
+		},
+		Threats: []brief.Threat{
+			{
+				ID:           "xss",
+				CWE:          "CWE-79",
+				OWASP:        "A03:2021",
+				Title:        "Cross-Site Scripting",
+				IntroducedBy: []string{"Rails"},
+				Note:         "Renders data into output",
+			},
+			{
+				ID:           "sql_injection",
+				CWE:          "CWE-89",
+				OWASP:        "A03:2021",
+				Title:        "SQL Injection",
+				IntroducedBy: []string{"ActiveRecord", "Rails"},
+			},
+		},
+	}
+}
+
+func TestThreatHuman(t *testing.T) {
+	var buf bytes.Buffer
+	ThreatHuman(&buf, sampleThreatReport())
+	out := buf.String()
+
+	checks := []string{
+		"Detected: ruby",
+		"Stack:    Rails, Ruby",
+		"xss",
+		"Cross-Site Scripting",
+		"CWE-79 A03:2021",
+		"via Rails",
+		"Renders data into output",
+		"sql_injection",
+		"via ActiveRecord, Rails",
+	}
+	for _, want := range checks {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\ngot:\n%s", want, out)
+		}
+	}
+}
+
+func TestThreatHumanEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	ThreatHuman(&buf, &brief.ThreatReport{})
+	if !strings.Contains(buf.String(), "No security data available") {
+		t.Errorf("expected empty message, got:\n%s", buf.String())
+	}
+}
+
+func TestThreatJSON(t *testing.T) {
+	var buf bytes.Buffer
+	if err := ThreatJSON(&buf, sampleThreatReport()); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, `"id": "xss"`) {
+		t.Errorf("expected xss in JSON, got:\n%s", out)
+	}
+	if !strings.Contains(out, `"introduced_by"`) {
+		t.Errorf("expected introduced_by field, got:\n%s", out)
+	}
+}
+
+func sampleSinkReport() *brief.SinkReport {
+	return &brief.SinkReport{
+		Sinks: []brief.SinkEntry{
+			{Symbol: "eval", Tool: "Ruby", Threat: "code_injection", CWE: "CWE-95"},
+			{Symbol: "system", Tool: "Ruby", Threat: "command_injection", CWE: "CWE-78", Note: "Spawns shell"},
+			{Symbol: "html_safe", Tool: "Rails", Threat: "xss", CWE: "CWE-79"},
+		},
+	}
+}
+
+func TestSinksHuman(t *testing.T) {
+	var buf bytes.Buffer
+	SinksHuman(&buf, sampleSinkReport())
+	out := buf.String()
+
+	checks := []string{
+		"Ruby:",
+		"eval",
+		"code_injection",
+		"CWE-95",
+		"system",
+		"Spawns shell",
+		"Rails:",
+		"html_safe",
+	}
+	for _, want := range checks {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\ngot:\n%s", want, out)
+		}
+	}
+
+	// Ruby section should appear before Rails section (input order preserved).
+	rubyIdx := strings.Index(out, "Ruby:")
+	railsIdx := strings.Index(out, "Rails:")
+	if rubyIdx > railsIdx {
+		t.Error("expected tool sections in input order")
+	}
+}
+
+func TestSinksHumanEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	SinksHuman(&buf, &brief.SinkReport{})
+	if !strings.Contains(buf.String(), "No sink data available") {
+		t.Errorf("expected empty message, got:\n%s", buf.String())
+	}
+}
+
+func TestSinksJSON(t *testing.T) {
+	var buf bytes.Buffer
+	if err := SinksJSON(&buf, sampleSinkReport()); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, `"symbol": "eval"`) {
+		t.Errorf("expected eval in JSON, got:\n%s", out)
+	}
+}


### PR DESCRIPTION
`threat-model` resolves each detected tool's `[taxonomy]` tags against the mappings in `_threats.toml`. Match is conjunctive: a tool needs all of a mapping's tags to fire it, so `role:framework + layer:backend` only matches server-side frameworks, not React. Matched threat IDs union with explicit `[security].threats`, then resolve against the registry for CWE/OWASP. `sinks` just collects `[[security.sinks]]` from each detected tool, filling CWE from the registry when the sink omits it.

Pulled out a `runDetection` helper for the shared preamble (flags, KB load, engine run, format resolution) which shrank `cmdMissing` alongside the two new commands and cleared dupl. Output sorted everywhere for byte-identical runs.

On the Rails fixture eight threats fire from three matched mappings, four sinks come from `ruby/language.toml`. Go fixture correctly reports nothing since no Go tools have security data yet.

Closes #14