### PR TITLE
Hand-classify [taxonomy] for build, database, environment, monorepo tools

### DIFF
--- a/knowledge/_shared/asdf.toml
+++ b/knowledge/_shared/asdf.toml
@@ -11,3 +11,6 @@ files = [".tool-versions"]
 
 [config]
 files = [".tool-versions"]
+
+[taxonomy]
+role = ["cli-tool"]

--- a/knowledge/_shared/atlas.toml
+++ b/knowledge/_shared/atlas.toml
@@ -14,3 +14,8 @@ run = "atlas schema apply"
 
 [config]
 files = ["atlas.hcl", "atlas.yaml"]
+
+[taxonomy]
+role = ["cli-tool"]
+function = ["database-management"]
+layer = ["data-layer"]

--- a/knowledge/_shared/bazel.toml
+++ b/knowledge/_shared/bazel.toml
@@ -15,3 +15,6 @@ alternatives = ["bazel test //..."]
 
 [config]
 files = ["WORKSPACE", "WORKSPACE.bazel", "MODULE.bazel", ".bazelrc"]
+
+[taxonomy]
+role = ["build-tool", "orchestrator"]

--- a/knowledge/_shared/dbmate.toml
+++ b/knowledge/_shared/dbmate.toml
@@ -15,3 +15,8 @@ alternatives = ["dbmate new"]
 
 [config]
 files = [".dbmate.yml"]
+
+[taxonomy]
+role = ["cli-tool"]
+function = ["database-management"]
+layer = ["data-layer"]

--- a/knowledge/_shared/direnv.toml
+++ b/knowledge/_shared/direnv.toml
@@ -11,3 +11,7 @@ files = [".envrc"]
 
 [config]
 files = [".envrc"]
+
+[taxonomy]
+role = ["cli-tool"]
+function = ["secrets-management"]

--- a/knowledge/_shared/dotenv.toml
+++ b/knowledge/_shared/dotenv.toml
@@ -9,3 +9,7 @@ files = [".env", ".env.example", ".env.sample", ".env.template"]
 
 [config]
 files = [".env", ".env.example", ".env.sample", ".env.template"]
+
+[taxonomy]
+role = ["library"]
+function = ["secrets-management"]

--- a/knowledge/_shared/goreleaser.toml
+++ b/knowledge/_shared/goreleaser.toml
@@ -15,3 +15,7 @@ alternatives = ["goreleaser build --snapshot"]
 
 [config]
 files = [".goreleaser.yaml", ".goreleaser.yml", "goreleaser.yaml", "goreleaser.yml"]
+
+[taxonomy]
+role = ["build-tool"]
+function = ["deployment"]

--- a/knowledge/_shared/jetbrains.toml
+++ b/knowledge/_shared/jetbrains.toml
@@ -9,3 +9,6 @@ files = [".idea/"]
 
 [config]
 files = [".idea/"]
+
+[taxonomy]
+role = ["editor"]

--- a/knowledge/_shared/launchdarkly.toml
+++ b/knowledge/_shared/launchdarkly.toml
@@ -7,3 +7,7 @@ description = "Feature flag management platform"
 
 [detect]
 dependencies = ["launchdarkly-server-sdk", "launchdarkly-node-server-sdk", "@launchdarkly/node-server-sdk", "launchdarkly-react-client-sdk"]
+
+[taxonomy]
+role = ["service"]
+function = ["feature-flags"]

--- a/knowledge/_shared/mise.toml
+++ b/knowledge/_shared/mise.toml
@@ -14,3 +14,6 @@ run = "mise install"
 
 [config]
 files = [".mise.toml", "mise.toml"]
+
+[taxonomy]
+role = ["cli-tool"]

--- a/knowledge/_shared/moon.toml
+++ b/knowledge/_shared/moon.toml
@@ -14,3 +14,6 @@ run = "moon run"
 
 [config]
 files = [".moon/workspace.yml"]
+
+[taxonomy]
+role = ["build-tool", "orchestrator"]

--- a/knowledge/_shared/sass.toml
+++ b/knowledge/_shared/sass.toml
@@ -10,3 +10,8 @@ description = "CSS preprocessor"
 files = ["**/*.scss", "**/*.sass"]
 dependencies = ["sass", "sass-rails"]
 dev_dependencies = ["sass"]
+
+[taxonomy]
+role = ["compiler"]
+layer = ["frontend"]
+domain = ["web-development"]

--- a/knowledge/_shared/sqlite.toml
+++ b/knowledge/_shared/sqlite.toml
@@ -25,3 +25,7 @@ dependencies = [
     "github.com/glebarez/sqlite",
 ]
 ".gitignore" = ["*.sqlite", "*.sqlite3"]
+
+[taxonomy]
+role = ["database-system"]
+layer = ["data-layer"]

--- a/knowledge/_shared/tauri.toml
+++ b/knowledge/_shared/tauri.toml
@@ -15,3 +15,8 @@ alternatives = ["cargo tauri dev"]
 
 [config]
 files = ["tauri.conf.json", "src-tauri/tauri.conf.json"]
+
+[taxonomy]
+role = ["framework"]
+layer = ["application-layer"]
+domain = ["desktop-development"]

--- a/knowledge/_shared/unleash.toml
+++ b/knowledge/_shared/unleash.toml
@@ -8,3 +8,7 @@ description = "Open-source feature flag management"
 
 [detect]
 dependencies = ["unleash-client", "@unleash/proxy-client-react"]
+
+[taxonomy]
+role = ["service"]
+function = ["feature-flags"]

--- a/knowledge/_shared/vscode.toml
+++ b/knowledge/_shared/vscode.toml
@@ -10,3 +10,6 @@ files = [".vscode/settings.json", ".vscode/extensions.json"]
 
 [config]
 files = [".vscode/settings.json", ".vscode/extensions.json", ".vscode/launch.json", ".vscode/tasks.json"]
+
+[taxonomy]
+role = ["editor"]

--- a/knowledge/c/autotools.toml
+++ b/knowledge/c/autotools.toml
@@ -15,3 +15,6 @@ alternatives = ["autoreconf -i && ./configure && make"]
 
 [config]
 files = ["configure.ac", "Makefile.am"]
+
+[taxonomy]
+role = ["build-tool"]

--- a/knowledge/c/cmake.toml
+++ b/knowledge/c/cmake.toml
@@ -16,3 +16,6 @@ alternatives = ["cmake -B build && cmake --build build"]
 
 [config]
 files = ["CMakeLists.txt", "CMakePresets.json"]
+
+[taxonomy]
+role = ["build-tool"]

--- a/knowledge/c/make.toml
+++ b/knowledge/c/make.toml
@@ -12,3 +12,6 @@ ecosystems = ["c", "cpp"]
 [commands]
 run = "make"
 alternatives = ["make all", "make clean"]
+
+[taxonomy]
+role = ["build-tool"]

--- a/knowledge/c/meson.toml
+++ b/knowledge/c/meson.toml
@@ -16,3 +16,6 @@ alternatives = ["meson setup build && meson compile -C build"]
 
 [config]
 files = ["meson.build", "meson_options.txt"]
+
+[taxonomy]
+role = ["build-tool"]

--- a/knowledge/dart/flutter.toml
+++ b/knowledge/dart/flutter.toml
@@ -14,3 +14,8 @@ ecosystems = ["dart"]
 
 [commands]
 run = "flutter run"
+
+[taxonomy]
+role = ["framework"]
+layer = ["frontend", "application-layer"]
+domain = ["mobile-development"]

--- a/knowledge/elixir/ecto.toml
+++ b/knowledge/elixir/ecto.toml
@@ -15,3 +15,8 @@ ecosystems = ["elixir"]
 
 [commands]
 run = "mix ecto.migrate"
+
+[taxonomy]
+role = ["library"]
+function = ["data-mapping", "validation"]
+layer = ["data-layer"]

--- a/knowledge/elixir/phoenix.toml
+++ b/knowledge/elixir/phoenix.toml
@@ -17,3 +17,9 @@ run = "mix phx.server"
 
 [config]
 files = ["config/config.exs"]
+
+[taxonomy]
+role = ["framework"]
+function = ["api-development", "templating"]
+layer = ["backend", "full-stack"]
+domain = ["web-development"]

--- a/knowledge/go/chi.toml
+++ b/knowledge/go/chi.toml
@@ -12,3 +12,9 @@ ecosystems = ["go"]
 
 [commands]
 run = "go run ."
+
+[taxonomy]
+role = ["library"]
+function = ["api-development"]
+layer = ["backend"]
+domain = ["web-development"]

--- a/knowledge/go/echo.toml
+++ b/knowledge/go/echo.toml
@@ -12,3 +12,9 @@ ecosystems = ["go"]
 
 [commands]
 run = "go run ."
+
+[taxonomy]
+role = ["framework"]
+function = ["api-development"]
+layer = ["backend"]
+domain = ["web-development"]

--- a/knowledge/go/fiber.toml
+++ b/knowledge/go/fiber.toml
@@ -12,3 +12,9 @@ ecosystems = ["go"]
 
 [commands]
 run = "go run ."
+
+[taxonomy]
+role = ["framework"]
+function = ["api-development"]
+layer = ["backend"]
+domain = ["web-development"]

--- a/knowledge/go/gin.toml
+++ b/knowledge/go/gin.toml
@@ -11,3 +11,9 @@ ecosystems = ["go"]
 
 [detect.file_contains]
 "go.mod" = ["github.com/gin-gonic/gin"]
+
+[taxonomy]
+role = ["framework"]
+function = ["api-development"]
+layer = ["backend"]
+domain = ["web-development"]

--- a/knowledge/go/go-workspace.toml
+++ b/knowledge/go/go-workspace.toml
@@ -11,3 +11,6 @@ ecosystems = ["go"]
 
 [config]
 files = ["go.work", "go.work.sum"]
+
+[taxonomy]
+role = ["build-tool"]

--- a/knowledge/go/goose.toml
+++ b/knowledge/go/goose.toml
@@ -19,3 +19,8 @@ alternatives = ["goose create"]
 
 [config]
 files = ["migrations/"]
+
+[taxonomy]
+role = ["cli-tool"]
+function = ["database-management"]
+layer = ["data-layer"]

--- a/knowledge/go/gorm.toml
+++ b/knowledge/go/gorm.toml
@@ -11,3 +11,8 @@ ecosystems = ["go"]
 
 [detect.file_contains]
 "go.mod" = ["gorm.io/gorm"]
+
+[taxonomy]
+role = ["library"]
+function = ["data-mapping"]
+layer = ["data-layer"]

--- a/knowledge/go/mage.toml
+++ b/knowledge/go/mage.toml
@@ -16,3 +16,6 @@ alternatives = ["go run mage.go"]
 
 [config]
 files = ["magefile.go", "magefiles/"]
+
+[taxonomy]
+role = ["build-tool"]

--- a/knowledge/go/pgx.toml
+++ b/knowledge/go/pgx.toml
@@ -9,3 +9,8 @@ description = "PostgreSQL driver and toolkit for Go"
 [detect]
 dependencies = ["github.com/jackc/pgx", "github.com/jackc/pgx/v4", "github.com/jackc/pgx/v5"]
 ecosystems = ["go"]
+
+[taxonomy]
+role = ["library"]
+function = ["data-mapping"]
+layer = ["data-layer"]

--- a/knowledge/go/sqlx.toml
+++ b/knowledge/go/sqlx.toml
@@ -9,3 +9,8 @@ description = "Extensions to Go database/sql"
 [detect]
 dependencies = ["github.com/jmoiron/sqlx"]
 ecosystems = ["go"]
+
+[taxonomy]
+role = ["library"]
+function = ["data-mapping"]
+layer = ["data-layer"]

--- a/knowledge/java/flyway.toml
+++ b/knowledge/java/flyway.toml
@@ -15,3 +15,8 @@ run = "flyway migrate"
 
 [config]
 files = ["flyway.conf", "flyway.toml"]
+
+[taxonomy]
+role = ["cli-tool"]
+function = ["database-management"]
+layer = ["data-layer"]

--- a/knowledge/java/liquibase.toml
+++ b/knowledge/java/liquibase.toml
@@ -15,3 +15,8 @@ run = "liquibase update"
 
 [config]
 files = ["liquibase.properties", "liquibase.yml", "liquibase.yaml"]
+
+[taxonomy]
+role = ["cli-tool"]
+function = ["database-management"]
+layer = ["data-layer"]

--- a/knowledge/java/spring-boot.toml
+++ b/knowledge/java/spring-boot.toml
@@ -12,3 +12,9 @@ ecosystems = ["java", "kotlin"]
 
 [config]
 files = ["src/main/resources/application.properties", "src/main/resources/application.yml"]
+
+[taxonomy]
+role = ["framework"]
+function = ["api-development", "dependency-injection", "data-mapping"]
+layer = ["backend", "full-stack"]
+domain = ["web-development"]

--- a/knowledge/node/adonisjs.toml
+++ b/knowledge/node/adonisjs.toml
@@ -17,3 +17,9 @@ alternatives = ["node ace build"]
 
 [config]
 files = ["adonisrc.ts", "adonisrc.js", ".adonisrc.json"]
+
+[taxonomy]
+role = ["framework"]
+function = ["api-development", "templating", "data-mapping", "authentication"]
+layer = ["backend", "full-stack"]
+domain = ["web-development"]

--- a/knowledge/node/angular.toml
+++ b/knowledge/node/angular.toml
@@ -17,3 +17,9 @@ alternatives = ["npx ng build"]
 
 [config]
 files = ["angular.json"]
+
+[taxonomy]
+role = ["framework"]
+function = ["templating"]
+layer = ["frontend"]
+domain = ["web-development"]

--- a/knowledge/node/astro.toml
+++ b/knowledge/node/astro.toml
@@ -17,3 +17,9 @@ alternatives = ["npx astro build"]
 
 [config]
 files = ["astro.config.mjs", "astro.config.ts", "astro.config.js"]
+
+[taxonomy]
+role = ["framework"]
+function = ["templating"]
+layer = ["frontend", "full-stack"]
+domain = ["web-development", "content-management"]

--- a/knowledge/node/drizzle.toml
+++ b/knowledge/node/drizzle.toml
@@ -18,3 +18,8 @@ alternatives = ["npx drizzle-kit generate", "npx drizzle-kit migrate"]
 
 [config]
 files = ["drizzle.config.ts", "drizzle.config.js"]
+
+[taxonomy]
+role = ["library"]
+function = ["data-mapping"]
+layer = ["data-layer"]

--- a/knowledge/node/electron.toml
+++ b/knowledge/node/electron.toml
@@ -12,3 +12,8 @@ ecosystems = ["node"]
 
 [commands]
 run = "npx electron ."
+
+[taxonomy]
+role = ["framework"]
+layer = ["application-layer"]
+domain = ["desktop-development"]

--- a/knowledge/node/eleventy.toml
+++ b/knowledge/node/eleventy.toml
@@ -18,3 +18,9 @@ alternatives = ["npx eleventy"]
 
 [config]
 files = [".eleventy.js", "eleventy.config.js", "eleventy.config.mjs", "eleventy.config.cjs"]
+
+[taxonomy]
+role = ["framework"]
+function = ["templating"]
+layer = ["frontend"]
+domain = ["web-development", "content-management"]

--- a/knowledge/node/ember.toml
+++ b/knowledge/node/ember.toml
@@ -17,3 +17,9 @@ alternatives = ["npx ember build"]
 
 [config]
 files = [".ember-cli", "ember-cli-build.js"]
+
+[taxonomy]
+role = ["framework"]
+function = ["templating"]
+layer = ["frontend"]
+domain = ["web-development"]

--- a/knowledge/node/esbuild.toml
+++ b/knowledge/node/esbuild.toml
@@ -15,3 +15,8 @@ run = "npx esbuild"
 
 [config]
 files = []
+
+[taxonomy]
+role = ["build-tool", "compiler"]
+function = ["bundling"]
+layer = ["frontend"]

--- a/knowledge/node/express.toml
+++ b/knowledge/node/express.toml
@@ -9,3 +9,9 @@ description = "Web framework for Node.js"
 [detect]
 dependencies = ["express"]
 ecosystems = ["node"]
+
+[taxonomy]
+role = ["framework"]
+function = ["api-development"]
+layer = ["backend"]
+domain = ["web-development"]

--- a/knowledge/node/fastify.toml
+++ b/knowledge/node/fastify.toml
@@ -9,3 +9,9 @@ description = "Fast web framework for Node.js"
 [detect]
 dependencies = ["fastify"]
 ecosystems = ["node"]
+
+[taxonomy]
+role = ["framework"]
+function = ["api-development"]
+layer = ["backend"]
+domain = ["web-development"]

--- a/knowledge/node/gatsby.toml
+++ b/knowledge/node/gatsby.toml
@@ -17,3 +17,9 @@ alternatives = ["npx gatsby build"]
 
 [config]
 files = ["gatsby-config.js", "gatsby-config.ts", "gatsby-node.js"]
+
+[taxonomy]
+role = ["framework"]
+function = ["templating"]
+layer = ["frontend"]
+domain = ["web-development", "content-management"]

--- a/knowledge/node/hono.toml
+++ b/knowledge/node/hono.toml
@@ -9,3 +9,9 @@ description = "Lightweight web framework for multiple runtimes"
 [detect]
 dependencies = ["hono"]
 ecosystems = ["node"]
+
+[taxonomy]
+role = ["framework"]
+function = ["api-development"]
+layer = ["backend", "edge"]
+domain = ["web-development"]

--- a/knowledge/node/knex.toml
+++ b/knowledge/node/knex.toml
@@ -16,3 +16,8 @@ run = "npx knex migrate:latest"
 
 [config]
 files = ["knexfile.js", "knexfile.ts"]
+
+[taxonomy]
+role = ["library"]
+function = ["data-mapping"]
+layer = ["data-layer"]

--- a/knowledge/node/koa.toml
+++ b/knowledge/node/koa.toml
@@ -9,3 +9,9 @@ description = "Expressive HTTP middleware framework for Node.js"
 [detect]
 dependencies = ["koa"]
 ecosystems = ["node"]
+
+[taxonomy]
+role = ["framework"]
+function = ["api-development"]
+layer = ["backend"]
+domain = ["web-development"]

--- a/knowledge/node/lerna.toml
+++ b/knowledge/node/lerna.toml
@@ -17,3 +17,6 @@ alternatives = ["npx lerna publish"]
 
 [config]
 files = ["lerna.json"]
+
+[taxonomy]
+role = ["build-tool", "orchestrator"]

--- a/knowledge/node/less.toml
+++ b/knowledge/node/less.toml
@@ -13,3 +13,8 @@ ecosystems = ["node"]
 
 [commands]
 run = "npx lessc"
+
+[taxonomy]
+role = ["compiler"]
+layer = ["frontend"]
+domain = ["web-development"]

--- a/knowledge/node/mikro-orm.toml
+++ b/knowledge/node/mikro-orm.toml
@@ -9,3 +9,8 @@ description = "TypeScript ORM with data mapper pattern"
 [detect]
 dependencies = ["@mikro-orm/core"]
 ecosystems = ["node"]
+
+[taxonomy]
+role = ["library"]
+function = ["data-mapping"]
+layer = ["data-layer"]

--- a/knowledge/node/mongoose.toml
+++ b/knowledge/node/mongoose.toml
@@ -9,3 +9,8 @@ description = "MongoDB object modeling for Node.js"
 [detect]
 dependencies = ["mongoose"]
 ecosystems = ["node"]
+
+[taxonomy]
+role = ["library"]
+function = ["data-mapping", "validation"]
+layer = ["data-layer"]

--- a/knowledge/node/nestjs.toml
+++ b/knowledge/node/nestjs.toml
@@ -17,3 +17,9 @@ alternatives = ["npx nest build"]
 
 [config]
 files = ["nest-cli.json"]
+
+[taxonomy]
+role = ["framework"]
+function = ["api-development", "dependency-injection"]
+layer = ["backend"]
+domain = ["web-development"]

--- a/knowledge/node/nextjs.toml
+++ b/knowledge/node/nextjs.toml
@@ -20,3 +20,9 @@ alternatives = ["npx next build"]
 
 [config]
 files = ["next.config.js", "next.config.mjs", "next.config.ts"]
+
+[taxonomy]
+role = ["framework"]
+function = ["api-development", "templating"]
+layer = ["full-stack", "frontend", "backend"]
+domain = ["web-development"]

--- a/knowledge/node/nuxt.toml
+++ b/knowledge/node/nuxt.toml
@@ -20,3 +20,9 @@ alternatives = ["npx nuxt build"]
 
 [config]
 files = ["nuxt.config.ts", "nuxt.config.js"]
+
+[taxonomy]
+role = ["framework"]
+function = ["api-development", "templating"]
+layer = ["full-stack", "frontend", "backend"]
+domain = ["web-development"]

--- a/knowledge/node/nx.toml
+++ b/knowledge/node/nx.toml
@@ -17,3 +17,6 @@ alternatives = ["npx nx graph"]
 
 [config]
 files = ["nx.json"]
+
+[taxonomy]
+role = ["build-tool", "orchestrator"]

--- a/knowledge/node/parcel.toml
+++ b/knowledge/node/parcel.toml
@@ -17,3 +17,8 @@ alternatives = ["npx parcel build"]
 
 [config]
 files = [".parcelrc", ".parcelrc.json"]
+
+[taxonomy]
+role = ["build-tool"]
+function = ["bundling"]
+layer = ["frontend"]

--- a/knowledge/node/pnpm-workspaces.toml
+++ b/knowledge/node/pnpm-workspaces.toml
@@ -11,3 +11,6 @@ ecosystems = ["node"]
 
 [config]
 files = ["pnpm-workspace.yaml"]
+
+[taxonomy]
+role = ["build-tool"]

--- a/knowledge/node/postcss.toml
+++ b/knowledge/node/postcss.toml
@@ -13,3 +13,8 @@ ecosystems = ["node"]
 
 [config]
 files = ["postcss.config.js", "postcss.config.mjs", "postcss.config.cjs", "postcss.config.ts", ".postcssrc", ".postcssrc.json"]
+
+[taxonomy]
+role = ["build-tool"]
+layer = ["frontend"]
+domain = ["web-development"]

--- a/knowledge/node/prisma.toml
+++ b/knowledge/node/prisma.toml
@@ -18,3 +18,8 @@ alternatives = ["npx prisma db push", "npx prisma generate"]
 
 [config]
 files = ["prisma/schema.prisma"]
+
+[taxonomy]
+role = ["library"]
+function = ["data-mapping", "code-generation"]
+layer = ["data-layer"]

--- a/knowledge/node/qwik.toml
+++ b/knowledge/node/qwik.toml
@@ -9,3 +9,9 @@ description = "Resumable web framework"
 [detect]
 dependencies = ["@builder.io/qwik"]
 ecosystems = ["node"]
+
+[taxonomy]
+role = ["framework"]
+function = ["templating"]
+layer = ["frontend", "full-stack"]
+domain = ["web-development"]

--- a/knowledge/node/react-native.toml
+++ b/knowledge/node/react-native.toml
@@ -12,3 +12,8 @@ ecosystems = ["node"]
 
 [commands]
 run = "npx react-native start"
+
+[taxonomy]
+role = ["framework"]
+layer = ["frontend", "application-layer"]
+domain = ["mobile-development"]

--- a/knowledge/node/react.toml
+++ b/knowledge/node/react.toml
@@ -12,3 +12,9 @@ ecosystems = ["node"]
 
 [commands]
 run = "npm run dev"
+
+[taxonomy]
+role = ["library"]
+function = ["templating"]
+layer = ["frontend"]
+domain = ["web-development"]

--- a/knowledge/node/remix.toml
+++ b/knowledge/node/remix.toml
@@ -17,3 +17,9 @@ alternatives = ["npx remix build"]
 
 [config]
 files = ["remix.config.js", "remix.config.ts"]
+
+[taxonomy]
+role = ["framework"]
+function = ["api-development", "templating"]
+layer = ["full-stack", "frontend", "backend"]
+domain = ["web-development"]

--- a/knowledge/node/rollup.toml
+++ b/knowledge/node/rollup.toml
@@ -16,3 +16,8 @@ run = "npx rollup -c"
 
 [config]
 files = ["rollup.config.js", "rollup.config.ts", "rollup.config.mjs"]
+
+[taxonomy]
+role = ["build-tool"]
+function = ["bundling"]
+layer = ["frontend"]

--- a/knowledge/node/rspack.toml
+++ b/knowledge/node/rspack.toml
@@ -17,3 +17,8 @@ alternatives = ["npx rspack serve"]
 
 [config]
 files = ["rspack.config.js", "rspack.config.ts"]
+
+[taxonomy]
+role = ["build-tool"]
+function = ["bundling"]
+layer = ["frontend"]

--- a/knowledge/node/rush.toml
+++ b/knowledge/node/rush.toml
@@ -16,3 +16,6 @@ alternatives = ["rush build", "rush update"]
 
 [config]
 files = ["rush.json"]
+
+[taxonomy]
+role = ["build-tool", "orchestrator"]

--- a/knowledge/node/sequelize.toml
+++ b/knowledge/node/sequelize.toml
@@ -16,3 +16,8 @@ run = "npx sequelize-cli db:migrate"
 
 [config]
 files = [".sequelizerc"]
+
+[taxonomy]
+role = ["library"]
+function = ["data-mapping"]
+layer = ["data-layer"]

--- a/knowledge/node/solidjs.toml
+++ b/knowledge/node/solidjs.toml
@@ -9,3 +9,9 @@ description = "Reactive JavaScript UI library"
 [detect]
 dependencies = ["solid-js"]
 ecosystems = ["node"]
+
+[taxonomy]
+role = ["library"]
+function = ["templating"]
+layer = ["frontend"]
+domain = ["web-development"]

--- a/knowledge/node/svelte.toml
+++ b/knowledge/node/svelte.toml
@@ -16,3 +16,9 @@ run = "npm run dev"
 
 [config]
 files = ["svelte.config.js", "svelte.config.ts"]
+
+[taxonomy]
+role = ["framework", "compiler"]
+function = ["templating"]
+layer = ["frontend"]
+domain = ["web-development"]

--- a/knowledge/node/sveltekit.toml
+++ b/knowledge/node/sveltekit.toml
@@ -20,3 +20,9 @@ alternatives = ["npx vite build"]
 
 [config]
 files = ["svelte.config.js", "svelte.config.ts"]
+
+[taxonomy]
+role = ["framework"]
+function = ["api-development", "templating"]
+layer = ["full-stack", "frontend", "backend"]
+domain = ["web-development"]

--- a/knowledge/node/swc.toml
+++ b/knowledge/node/swc.toml
@@ -16,3 +16,8 @@ run = "npx swc"
 
 [config]
 files = [".swcrc"]
+
+[taxonomy]
+role = ["compiler"]
+function = ["bundling"]
+layer = ["frontend"]

--- a/knowledge/node/tailwind.toml
+++ b/knowledge/node/tailwind.toml
@@ -14,3 +14,8 @@ ecosystems = ["node"]
 
 [config]
 files = ["tailwind.config.js", "tailwind.config.ts", "tailwind.config.mjs", "tailwind.config.cjs"]
+
+[taxonomy]
+role = ["library"]
+layer = ["frontend"]
+domain = ["web-development"]

--- a/knowledge/node/tsup.toml
+++ b/knowledge/node/tsup.toml
@@ -16,3 +16,7 @@ run = "npx tsup"
 
 [config]
 files = ["tsup.config.ts", "tsup.config.js", "tsup.config.mjs", "tsup.config.cjs"]
+
+[taxonomy]
+role = ["build-tool"]
+function = ["bundling"]

--- a/knowledge/node/turborepo.toml
+++ b/knowledge/node/turborepo.toml
@@ -20,3 +20,6 @@ alternatives = ["turbo run build"]
 
 [config]
 files = ["turbo.json"]
+
+[taxonomy]
+role = ["build-tool", "orchestrator"]

--- a/knowledge/node/typeorm.toml
+++ b/knowledge/node/typeorm.toml
@@ -16,3 +16,8 @@ run = "npx typeorm migration:run"
 
 [config]
 files = ["ormconfig.json", "ormconfig.yml", "ormconfig.yaml", "ormconfig.js", "ormconfig.ts"]
+
+[taxonomy]
+role = ["library"]
+function = ["data-mapping"]
+layer = ["data-layer"]

--- a/knowledge/node/unocss.toml
+++ b/knowledge/node/unocss.toml
@@ -16,3 +16,8 @@ run = "npx unocss"
 
 [config]
 files = ["uno.config.js", "uno.config.ts"]
+
+[taxonomy]
+role = ["library"]
+layer = ["frontend"]
+domain = ["web-development"]

--- a/knowledge/node/vite.toml
+++ b/knowledge/node/vite.toml
@@ -17,3 +17,8 @@ alternatives = ["npx vite build", "npx vite preview"]
 
 [config]
 files = ["vite.config.js", "vite.config.ts", "vite.config.mjs", "vite.config.mts"]
+
+[taxonomy]
+role = ["build-tool"]
+function = ["bundling"]
+layer = ["frontend"]

--- a/knowledge/node/volta.toml
+++ b/knowledge/node/volta.toml
@@ -14,3 +14,6 @@ ecosystems = ["node"]
 
 [config]
 files = ["package.json"]
+
+[taxonomy]
+role = ["cli-tool"]

--- a/knowledge/node/vue.toml
+++ b/knowledge/node/vue.toml
@@ -12,3 +12,9 @@ ecosystems = ["node"]
 
 [commands]
 run = "npm run dev"
+
+[taxonomy]
+role = ["framework"]
+function = ["templating"]
+layer = ["frontend"]
+domain = ["web-development"]

--- a/knowledge/node/webpack.toml
+++ b/knowledge/node/webpack.toml
@@ -17,3 +17,8 @@ alternatives = ["npx webpack serve"]
 
 [config]
 files = ["webpack.config.js", "webpack.config.ts", "webpack.config.mjs", "webpack.config.cjs"]
+
+[taxonomy]
+role = ["build-tool"]
+function = ["bundling"]
+layer = ["frontend"]

--- a/knowledge/node/yarn-workspaces.toml
+++ b/knowledge/node/yarn-workspaces.toml
@@ -13,3 +13,6 @@ ecosystems = ["node"]
 
 [commands]
 run = "yarn workspaces info"
+
+[taxonomy]
+role = ["build-tool"]

--- a/knowledge/ocaml/dune.toml
+++ b/knowledge/ocaml/dune.toml
@@ -16,3 +16,6 @@ alternatives = ["dune clean", "dune exec"]
 
 [config]
 files = ["dune-project", "dune"]
+
+[taxonomy]
+role = ["build-tool"]

--- a/knowledge/php/laravel.toml
+++ b/knowledge/php/laravel.toml
@@ -13,3 +13,9 @@ ecosystems = ["php"]
 
 [commands]
 run = "php artisan serve"
+
+[taxonomy]
+role = ["framework"]
+function = ["api-development", "templating", "data-mapping", "authentication"]
+layer = ["backend", "full-stack"]
+domain = ["web-development"]

--- a/knowledge/php/symfony.toml
+++ b/knowledge/php/symfony.toml
@@ -13,3 +13,9 @@ ecosystems = ["php"]
 [commands]
 run = "symfony server:start"
 alternatives = ["php bin/console server:run"]
+
+[taxonomy]
+role = ["framework"]
+function = ["api-development", "templating", "dependency-injection"]
+layer = ["backend", "full-stack"]
+domain = ["web-development"]

--- a/knowledge/python/alembic.toml
+++ b/knowledge/python/alembic.toml
@@ -17,3 +17,8 @@ alternatives = ["alembic revision --autogenerate"]
 
 [config]
 files = ["alembic.ini", "alembic/env.py"]
+
+[taxonomy]
+role = ["cli-tool"]
+function = ["database-management"]
+layer = ["data-layer"]

--- a/knowledge/python/django.toml
+++ b/knowledge/python/django.toml
@@ -16,3 +16,9 @@ run = "python manage.py runserver"
 
 [config]
 files = ["manage.py"]
+
+[taxonomy]
+role = ["framework"]
+function = ["api-development", "templating", "data-mapping", "authentication"]
+layer = ["backend", "full-stack"]
+domain = ["web-development"]

--- a/knowledge/python/fastapi.toml
+++ b/knowledge/python/fastapi.toml
@@ -12,3 +12,9 @@ ecosystems = ["python"]
 
 [commands]
 run = "uvicorn main:app --reload"
+
+[taxonomy]
+role = ["framework"]
+function = ["api-development", "validation"]
+layer = ["backend"]
+domain = ["web-development"]

--- a/knowledge/python/flask.toml
+++ b/knowledge/python/flask.toml
@@ -12,3 +12,9 @@ ecosystems = ["python"]
 
 [commands]
 run = "flask run"
+
+[taxonomy]
+role = ["framework"]
+function = ["api-development", "templating"]
+layer = ["backend"]
+domain = ["web-development"]

--- a/knowledge/python/pants.toml
+++ b/knowledge/python/pants.toml
@@ -16,3 +16,6 @@ alternatives = ["pants lint ::", "pants fmt ::"]
 
 [config]
 files = ["pants.toml"]
+
+[taxonomy]
+role = ["build-tool", "orchestrator"]

--- a/knowledge/python/peewee.toml
+++ b/knowledge/python/peewee.toml
@@ -9,3 +9,8 @@ description = "Small Python ORM"
 [detect]
 dependencies = ["peewee"]
 ecosystems = ["python"]
+
+[taxonomy]
+role = ["library"]
+function = ["data-mapping"]
+layer = ["data-layer"]

--- a/knowledge/python/pyenv.toml
+++ b/knowledge/python/pyenv.toml
@@ -12,3 +12,6 @@ ecosystems = ["python"]
 
 [config]
 files = [".python-version"]
+
+[taxonomy]
+role = ["cli-tool"]

--- a/knowledge/python/sqlalchemy.toml
+++ b/knowledge/python/sqlalchemy.toml
@@ -9,3 +9,8 @@ description = "Python SQL toolkit and ORM"
 [detect]
 dependencies = ["sqlalchemy", "SQLAlchemy"]
 ecosystems = ["python"]
+
+[taxonomy]
+role = ["library"]
+function = ["data-mapping"]
+layer = ["data-layer"]

--- a/knowledge/python/tortoise-orm.toml
+++ b/knowledge/python/tortoise-orm.toml
@@ -9,3 +9,8 @@ description = "Async ORM for Python"
 [detect]
 dependencies = ["tortoise-orm"]
 ecosystems = ["python"]
+
+[taxonomy]
+role = ["library"]
+function = ["data-mapping"]
+layer = ["data-layer"]

--- a/knowledge/ruby/activerecord.toml
+++ b/knowledge/ruby/activerecord.toml
@@ -17,3 +17,8 @@ alternatives = ["rake db:migrate"]
 
 [config]
 files = ["db/migrate/", "db/schema.rb", "config/database.yml"]
+
+[taxonomy]
+role = ["library"]
+function = ["data-mapping"]
+layer = ["data-layer"]

--- a/knowledge/ruby/flipper.toml
+++ b/knowledge/ruby/flipper.toml
@@ -9,3 +9,7 @@ description = "Feature flag library for Ruby"
 [detect]
 dependencies = ["flipper"]
 ecosystems = ["ruby"]
+
+[taxonomy]
+role = ["library"]
+function = ["feature-flags"]

--- a/knowledge/ruby/rake.toml
+++ b/knowledge/ruby/rake.toml
@@ -17,3 +17,7 @@ alternatives = ["rake"]
 
 [config]
 files = ["Rakefile", "rakefile", "Rakefile.rb", "rakefile.rb"]
+
+[taxonomy]
+role = ["build-tool"]
+function = ["automation"]

--- a/knowledge/ruby/sequel.toml
+++ b/knowledge/ruby/sequel.toml
@@ -9,3 +9,8 @@ description = "Database toolkit for Ruby"
 [detect]
 dependencies = ["sequel"]
 ecosystems = ["ruby"]
+
+[taxonomy]
+role = ["library"]
+function = ["data-mapping"]
+layer = ["data-layer"]

--- a/knowledge/ruby/sinatra.toml
+++ b/knowledge/ruby/sinatra.toml
@@ -12,3 +12,9 @@ ecosystems = ["ruby"]
 
 [commands]
 run = "ruby app.rb"
+
+[taxonomy]
+role = ["framework"]
+function = ["api-development", "templating"]
+layer = ["backend"]
+domain = ["web-development"]

--- a/knowledge/rust/actix.toml
+++ b/knowledge/rust/actix.toml
@@ -9,3 +9,9 @@ description = "Web framework for Rust"
 [detect]
 dependencies = ["actix-web"]
 ecosystems = ["rust"]
+
+[taxonomy]
+role = ["framework"]
+function = ["api-development"]
+layer = ["backend"]
+domain = ["web-development"]

--- a/knowledge/rust/axum.toml
+++ b/knowledge/rust/axum.toml
@@ -12,3 +12,9 @@ ecosystems = ["rust"]
 
 [commands]
 run = "cargo run"
+
+[taxonomy]
+role = ["framework"]
+function = ["api-development"]
+layer = ["backend"]
+domain = ["web-development"]

--- a/knowledge/rust/cargo-workspaces.toml
+++ b/knowledge/rust/cargo-workspaces.toml
@@ -13,3 +13,6 @@ ecosystems = ["rust"]
 
 [commands]
 run = "cargo build --workspace"
+
+[taxonomy]
+role = ["build-tool"]

--- a/knowledge/rust/cross-rs.toml
+++ b/knowledge/rust/cross-rs.toml
@@ -15,3 +15,6 @@ run = "cross build --target"
 
 [config]
 files = ["Cross.toml"]
+
+[taxonomy]
+role = ["build-tool"]

--- a/knowledge/rust/diesel.toml
+++ b/knowledge/rust/diesel.toml
@@ -17,3 +17,8 @@ alternatives = ["diesel migration generate"]
 
 [config]
 files = ["diesel.toml"]
+
+[taxonomy]
+role = ["library"]
+function = ["data-mapping"]
+layer = ["data-layer"]

--- a/knowledge/rust/rocket.toml
+++ b/knowledge/rust/rocket.toml
@@ -12,3 +12,9 @@ ecosystems = ["rust"]
 
 [commands]
 run = "cargo run"
+
+[taxonomy]
+role = ["framework"]
+function = ["api-development", "templating"]
+layer = ["backend"]
+domain = ["web-development"]

--- a/knowledge/solidity/foundry.toml
+++ b/knowledge/solidity/foundry.toml
@@ -16,3 +16,7 @@ alternatives = ["forge test"]
 
 [config]
 files = ["foundry.toml"]
+
+[taxonomy]
+role = ["build-tool", "testing-framework"]
+domain = ["blockchain"]

--- a/knowledge/solidity/hardhat.toml
+++ b/knowledge/solidity/hardhat.toml
@@ -17,3 +17,7 @@ alternatives = ["npx hardhat test"]
 
 [config]
 files = ["hardhat.config.js", "hardhat.config.ts"]
+
+[taxonomy]
+role = ["build-tool", "testing-framework"]
+domain = ["blockchain"]


### PR DESCRIPTION
Stacked on #22. The 109 tools that needed individual judgement rather than a category mapping.

Backend web frameworks get `role:framework` + `layer:backend` + `function:api-development` which fires the threat-model backend mapping. Full-stack metaframeworks (Next, Nuxt, SvelteKit, Remix) carry both frontend and backend layers. React and SolidJS are `role:library` not framework. Bundlers get `function:bundling`. ORMs get `function:data-mapping` which fires the SQL injection mapping; migration tools get `function:database-management` instead. Feature flag tools get `function:feature-flags`. Monorepo orchestrators get `role:build-tool` + `role:orchestrator`.

Django, Laravel, AdonisJS, Spring Boot get `function:data-mapping` since they bundle their own ORMs, unlike Rails where ActiveRecord is a separate tool def. Hono gets `layer:edge` alongside backend since it targets Cloudflare Workers etc.

All 446 tool defs now carry `[taxonomy]`.

Closes #15