### PR TITLE
Seed stdlib sinks for Ruby, Python, JavaScript, Go, PHP, Java

### DIFF
--- a/knowledge/go/language.toml
+++ b/knowledge/go/language.toml
@@ -9,3 +9,142 @@ description = "Statically typed, compiled programming language"
 [detect]
 files = ["go.mod", "*.go", "**/*.go"]
 ecosystems = ["go"]
+
+[[security.sinks]]
+symbol = "exec.Command"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "When args built via fmt.Sprintf or string concat"
+
+[[security.sinks]]
+symbol = "exec.CommandContext"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "syscall.Exec"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "text/template.Template.Execute"
+threat = "xss"
+cwe = "CWE-79"
+note = "text/template does not escape HTML; use html/template for web output"
+
+[[security.sinks]]
+symbol = "template.HTML"
+threat = "xss"
+cwe = "CWE-79"
+note = "html/template type that bypasses escaping"
+
+[[security.sinks]]
+symbol = "template.JS"
+threat = "xss"
+cwe = "CWE-79"
+
+[[security.sinks]]
+symbol = "template.URL"
+threat = "open_redirect"
+cwe = "CWE-601"
+
+[[security.sinks]]
+symbol = "sql.DB.Query"
+threat = "sql_injection"
+cwe = "CWE-89"
+note = "When query built via fmt.Sprintf; use parameterized $1, ?"
+
+[[security.sinks]]
+symbol = "sql.DB.Exec"
+threat = "sql_injection"
+cwe = "CWE-89"
+
+[[security.sinks]]
+symbol = "sql.DB.QueryRow"
+threat = "sql_injection"
+cwe = "CWE-89"
+
+[[security.sinks]]
+symbol = "filepath.Join"
+threat = "path_traversal"
+cwe = "CWE-22"
+note = "Does not prevent ../; pair with filepath.Clean and prefix check"
+
+[[security.sinks]]
+symbol = "os.Open"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "os.OpenFile"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "os.ReadFile"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "http.ServeFile"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "encoding/gob.Decoder.Decode"
+threat = "deserialization"
+cwe = "CWE-502"
+note = "Less risky than Java/Python serialization but trusts type info"
+
+[[security.sinks]]
+symbol = "xml.Decoder.Decode"
+threat = "xxe"
+cwe = "CWE-611"
+note = "Disable Strict and CharsetReader for untrusted input"
+
+[[security.sinks]]
+symbol = "http.Get"
+threat = "ssrf"
+cwe = "CWE-918"
+
+[[security.sinks]]
+symbol = "http.Post"
+threat = "ssrf"
+cwe = "CWE-918"
+
+[[security.sinks]]
+symbol = "http.Client.Do"
+threat = "ssrf"
+cwe = "CWE-918"
+
+[[security.sinks]]
+symbol = "http.Redirect"
+threat = "open_redirect"
+cwe = "CWE-601"
+
+[[security.sinks]]
+symbol = "unsafe.Pointer"
+threat = "code_injection"
+cwe = "CWE-119"
+note = "Memory safety, not injection per se; flagged for review"
+
+[[security.sinks]]
+symbol = "crypto/md5.New"
+threat = "weak_crypto"
+cwe = "CWE-327"
+
+[[security.sinks]]
+symbol = "crypto/sha1.New"
+threat = "weak_crypto"
+cwe = "CWE-327"
+
+[[security.sinks]]
+symbol = "crypto/des.NewCipher"
+threat = "weak_crypto"
+cwe = "CWE-327"
+
+[[security.sinks]]
+symbol = "math/rand.Intn"
+threat = "weak_crypto"
+cwe = "CWE-338"
+note = "Not cryptographically secure; use crypto/rand for security"

--- a/knowledge/java/language.toml
+++ b/knowledge/java/language.toml
@@ -8,3 +8,157 @@ description = "General-purpose, class-based, object-oriented programming languag
 [detect]
 files = ["pom.xml", "build.gradle", "build.gradle.kts", "*.java", "**/*.java"]
 ecosystems = ["java"]
+
+[[security.sinks]]
+symbol = "Runtime.exec"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "ProcessBuilder"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "When command list built from caller input"
+
+[[security.sinks]]
+symbol = "ObjectInputStream.readObject"
+threat = "deserialization"
+cwe = "CWE-502"
+note = "Java native serialization; gadget chains"
+
+[[security.sinks]]
+symbol = "XMLDecoder.readObject"
+threat = "deserialization"
+cwe = "CWE-502"
+
+[[security.sinks]]
+symbol = "Yaml.load"
+threat = "deserialization"
+cwe = "CWE-502"
+note = "SnakeYAML default constructor; use SafeConstructor"
+
+[[security.sinks]]
+symbol = "ScriptEngine.eval"
+threat = "code_injection"
+cwe = "CWE-95"
+note = "javax.script, Nashorn/Graal"
+
+[[security.sinks]]
+symbol = "Class.forName"
+threat = "unsafe_reflection"
+cwe = "CWE-470"
+note = "When class name is caller-controlled"
+
+[[security.sinks]]
+symbol = "Method.invoke"
+threat = "unsafe_reflection"
+cwe = "CWE-470"
+
+[[security.sinks]]
+symbol = "URLClassLoader"
+threat = "code_injection"
+cwe = "CWE-470"
+note = "Loads classes from caller-controlled URLs"
+
+[[security.sinks]]
+symbol = "Statement.execute"
+threat = "sql_injection"
+cwe = "CWE-89"
+note = "Use PreparedStatement with parameters"
+
+[[security.sinks]]
+symbol = "Statement.executeQuery"
+threat = "sql_injection"
+cwe = "CWE-89"
+
+[[security.sinks]]
+symbol = "Statement.executeUpdate"
+threat = "sql_injection"
+cwe = "CWE-89"
+
+[[security.sinks]]
+symbol = "DocumentBuilderFactory.newInstance"
+threat = "xxe"
+cwe = "CWE-611"
+note = "Default settings allow external entities; setFeature to disable"
+
+[[security.sinks]]
+symbol = "SAXParserFactory.newInstance"
+threat = "xxe"
+cwe = "CWE-611"
+
+[[security.sinks]]
+symbol = "XMLInputFactory.newInstance"
+threat = "xxe"
+cwe = "CWE-611"
+
+[[security.sinks]]
+symbol = "TransformerFactory.newInstance"
+threat = "xxe"
+cwe = "CWE-611"
+
+[[security.sinks]]
+symbol = "File"
+threat = "path_traversal"
+cwe = "CWE-22"
+note = "When path is caller-controlled; use getCanonicalPath check"
+
+[[security.sinks]]
+symbol = "Files.readAllBytes"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "FileInputStream"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "URL.openStream"
+threat = "ssrf"
+cwe = "CWE-918"
+
+[[security.sinks]]
+symbol = "URL.openConnection"
+threat = "ssrf"
+cwe = "CWE-918"
+
+[[security.sinks]]
+symbol = "HttpClient.send"
+threat = "ssrf"
+cwe = "CWE-918"
+note = "java.net.http"
+
+[[security.sinks]]
+symbol = "HttpServletResponse.sendRedirect"
+threat = "open_redirect"
+cwe = "CWE-601"
+
+[[security.sinks]]
+symbol = "MessageDigest.getInstance"
+threat = "weak_crypto"
+cwe = "CWE-327"
+note = "When algorithm is MD5 or SHA-1"
+
+[[security.sinks]]
+symbol = "Cipher.getInstance"
+threat = "weak_crypto"
+cwe = "CWE-327"
+note = "When algorithm is DES, ECB mode, or no padding spec"
+
+[[security.sinks]]
+symbol = "Random"
+threat = "weak_crypto"
+cwe = "CWE-338"
+note = "java.util.Random; use SecureRandom for security"
+
+[[security.sinks]]
+symbol = "InitialDirContext.search"
+threat = "ldap_injection"
+cwe = "CWE-90"
+
+[[security.sinks]]
+symbol = "Naming.lookup"
+threat = "code_injection"
+cwe = "CWE-470"
+note = "JNDI lookup with caller-controlled name; log4shell-class"

--- a/knowledge/node/language.toml
+++ b/knowledge/node/language.toml
@@ -8,3 +8,137 @@ description = "Dynamic programming language for the web"
 [detect]
 files = ["package.json", "*.js", "**/*.js", "*.mjs"]
 ecosystems = ["node"]
+
+[[security.sinks]]
+symbol = "eval"
+threat = "code_injection"
+cwe = "CWE-95"
+
+[[security.sinks]]
+symbol = "Function"
+threat = "code_injection"
+cwe = "CWE-95"
+note = "new Function(string) is eval"
+
+[[security.sinks]]
+symbol = "setTimeout"
+threat = "code_injection"
+cwe = "CWE-95"
+note = "Only with string argument"
+
+[[security.sinks]]
+symbol = "setInterval"
+threat = "code_injection"
+cwe = "CWE-95"
+note = "Only with string argument"
+
+[[security.sinks]]
+symbol = "child_process.exec"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "Spawns shell; prefer execFile or spawn with array args"
+
+[[security.sinks]]
+symbol = "child_process.execSync"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "child_process.spawn"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "Only with shell:true option"
+
+[[security.sinks]]
+symbol = "child_process.spawnSync"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "Only with shell:true option"
+
+[[security.sinks]]
+symbol = "vm.runInNewContext"
+threat = "code_injection"
+cwe = "CWE-95"
+note = "vm module is not a security sandbox"
+
+[[security.sinks]]
+symbol = "vm.runInThisContext"
+threat = "code_injection"
+cwe = "CWE-95"
+
+[[security.sinks]]
+symbol = "vm.Script"
+threat = "code_injection"
+cwe = "CWE-95"
+
+[[security.sinks]]
+symbol = "require"
+threat = "code_injection"
+cwe = "CWE-470"
+note = "When module path is caller-controlled"
+
+[[security.sinks]]
+symbol = "fs.readFile"
+threat = "path_traversal"
+cwe = "CWE-22"
+note = "When path is caller-controlled"
+
+[[security.sinks]]
+symbol = "fs.readFileSync"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "fs.writeFile"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "fs.writeFileSync"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "fs.createReadStream"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "path.join"
+threat = "path_traversal"
+cwe = "CWE-22"
+note = "Does not normalize ../; use path.resolve and check prefix"
+
+[[security.sinks]]
+symbol = "JSON.parse"
+threat = "dos"
+cwe = "CWE-400"
+note = "Prototype pollution via __proto__ in older parsers; size limits"
+
+[[security.sinks]]
+symbol = "Object.assign"
+threat = "mass_assignment"
+cwe = "CWE-915"
+note = "Prototype pollution when source is caller-controlled"
+
+[[security.sinks]]
+symbol = "node-serialize.unserialize"
+threat = "deserialization"
+cwe = "CWE-502"
+note = "node-serialize package, not stdlib"
+
+[[security.sinks]]
+symbol = "http.get"
+threat = "ssrf"
+cwe = "CWE-918"
+note = "When URL is caller-controlled"
+
+[[security.sinks]]
+symbol = "https.get"
+threat = "ssrf"
+cwe = "CWE-918"
+
+[[security.sinks]]
+symbol = "http.request"
+threat = "ssrf"
+cwe = "CWE-918"

--- a/knowledge/php/language.toml
+++ b/knowledge/php/language.toml
@@ -9,3 +9,175 @@ description = "General-purpose scripting language for web development"
 [detect]
 files = ["composer.json", "*.php", "**/*.php"]
 ecosystems = ["php"]
+
+[[security.sinks]]
+symbol = "eval"
+threat = "code_injection"
+cwe = "CWE-95"
+
+[[security.sinks]]
+symbol = "assert"
+threat = "code_injection"
+cwe = "CWE-95"
+note = "With string argument; deprecated in 7.2, removed in 8.0"
+
+[[security.sinks]]
+symbol = "create_function"
+threat = "code_injection"
+cwe = "CWE-95"
+note = "Removed in PHP 8.0"
+
+[[security.sinks]]
+symbol = "preg_replace"
+threat = "code_injection"
+cwe = "CWE-95"
+note = "With /e modifier; removed in PHP 7.0"
+
+[[security.sinks]]
+symbol = "exec"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "system"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "shell_exec"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "passthru"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "popen"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "proc_open"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "pcntl_exec"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "unserialize"
+threat = "deserialization"
+cwe = "CWE-502"
+
+[[security.sinks]]
+symbol = "include"
+threat = "code_injection"
+cwe = "CWE-98"
+note = "When path is caller-controlled; LFI/RFI"
+
+[[security.sinks]]
+symbol = "include_once"
+threat = "code_injection"
+cwe = "CWE-98"
+
+[[security.sinks]]
+symbol = "require"
+threat = "code_injection"
+cwe = "CWE-98"
+
+[[security.sinks]]
+symbol = "require_once"
+threat = "code_injection"
+cwe = "CWE-98"
+
+[[security.sinks]]
+symbol = "extract"
+threat = "mass_assignment"
+cwe = "CWE-621"
+note = "Imports array keys as variables; with EXTR_OVERWRITE"
+
+[[security.sinks]]
+symbol = "parse_str"
+threat = "mass_assignment"
+cwe = "CWE-621"
+note = "Without second arg, writes to current symbol table"
+
+[[security.sinks]]
+symbol = "file_get_contents"
+threat = "ssrf"
+cwe = "CWE-918"
+note = "Accepts URLs when allow_url_fopen is on"
+
+[[security.sinks]]
+symbol = "fopen"
+threat = "ssrf"
+cwe = "CWE-918"
+note = "Accepts URLs; also path traversal"
+
+[[security.sinks]]
+symbol = "curl_exec"
+threat = "ssrf"
+cwe = "CWE-918"
+
+[[security.sinks]]
+symbol = "readfile"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "header"
+threat = "open_redirect"
+cwe = "CWE-601"
+note = "With Location: and caller-controlled URL"
+
+[[security.sinks]]
+symbol = "echo"
+threat = "xss"
+cwe = "CWE-79"
+note = "Without htmlspecialchars on user input"
+
+[[security.sinks]]
+symbol = "print"
+threat = "xss"
+cwe = "CWE-79"
+
+[[security.sinks]]
+symbol = "simplexml_load_string"
+threat = "xxe"
+cwe = "CWE-611"
+note = "Without LIBXML_NOENT disabled"
+
+[[security.sinks]]
+symbol = "DOMDocument::loadXML"
+threat = "xxe"
+cwe = "CWE-611"
+
+[[security.sinks]]
+symbol = "mysqli_query"
+threat = "sql_injection"
+cwe = "CWE-89"
+note = "When query built via concatenation; use prepared statements"
+
+[[security.sinks]]
+symbol = "PDO::query"
+threat = "sql_injection"
+cwe = "CWE-89"
+
+[[security.sinks]]
+symbol = "PDO::exec"
+threat = "sql_injection"
+cwe = "CWE-89"
+
+[[security.sinks]]
+symbol = "md5"
+threat = "weak_crypto"
+cwe = "CWE-327"
+
+[[security.sinks]]
+symbol = "sha1"
+threat = "weak_crypto"
+cwe = "CWE-327"

--- a/knowledge/python/language.toml
+++ b/knowledge/python/language.toml
@@ -9,3 +9,136 @@ description = "High-level, general-purpose programming language"
 [detect]
 files = ["pyproject.toml", "setup.py", "setup.cfg", "requirements.txt", "*.py", "**/*.py"]
 ecosystems = ["python"]
+
+[[security.sinks]]
+symbol = "eval"
+threat = "code_injection"
+cwe = "CWE-95"
+
+[[security.sinks]]
+symbol = "exec"
+threat = "code_injection"
+cwe = "CWE-95"
+
+[[security.sinks]]
+symbol = "compile"
+threat = "code_injection"
+cwe = "CWE-95"
+
+[[security.sinks]]
+symbol = "__import__"
+threat = "code_injection"
+cwe = "CWE-470"
+note = "Dynamic module loading from string"
+
+[[security.sinks]]
+symbol = "os.system"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "os.popen"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "subprocess.run"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "Only with shell=True"
+
+[[security.sinks]]
+symbol = "subprocess.call"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "Only with shell=True"
+
+[[security.sinks]]
+symbol = "subprocess.Popen"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "Only with shell=True"
+
+[[security.sinks]]
+symbol = "subprocess.check_output"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "Only with shell=True"
+
+[[security.sinks]]
+symbol = "pickle.loads"
+threat = "deserialization"
+cwe = "CWE-502"
+
+[[security.sinks]]
+symbol = "pickle.load"
+threat = "deserialization"
+cwe = "CWE-502"
+
+[[security.sinks]]
+symbol = "marshal.loads"
+threat = "deserialization"
+cwe = "CWE-502"
+
+[[security.sinks]]
+symbol = "shelve.open"
+threat = "deserialization"
+cwe = "CWE-502"
+note = "Backed by pickle"
+
+[[security.sinks]]
+symbol = "yaml.load"
+threat = "deserialization"
+cwe = "CWE-502"
+note = "Without SafeLoader; use yaml.safe_load"
+
+[[security.sinks]]
+symbol = "yaml.unsafe_load"
+threat = "deserialization"
+cwe = "CWE-502"
+
+[[security.sinks]]
+symbol = "xml.etree.ElementTree.parse"
+threat = "xxe"
+cwe = "CWE-611"
+note = "Pre-3.8 default resolver; use defusedxml"
+
+[[security.sinks]]
+symbol = "xml.sax.parse"
+threat = "xxe"
+cwe = "CWE-611"
+
+[[security.sinks]]
+symbol = "open"
+threat = "path_traversal"
+cwe = "CWE-22"
+note = "When path is caller-controlled"
+
+[[security.sinks]]
+symbol = "tarfile.extractall"
+threat = "path_traversal"
+cwe = "CWE-22"
+note = "Pre-3.12 no filter; CVE-2007-4559"
+
+[[security.sinks]]
+symbol = "zipfile.extractall"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "tempfile.mktemp"
+threat = "path_traversal"
+cwe = "CWE-377"
+note = "Race condition; use mkstemp or NamedTemporaryFile"
+
+[[security.sinks]]
+symbol = "input"
+threat = "code_injection"
+cwe = "CWE-95"
+note = "Python 2 only; equivalent to eval(raw_input())"
+
+[[security.sinks]]
+symbol = "getattr"
+threat = "unsafe_reflection"
+cwe = "CWE-470"
+note = "When attribute name is caller-controlled"

--- a/knowledge/ruby/language.toml
+++ b/knowledge/ruby/language.toml
@@ -19,9 +19,77 @@ threat = "code_injection"
 cwe = "CWE-95"
 
 [[security.sinks]]
+symbol = "instance_eval"
+threat = "code_injection"
+cwe = "CWE-95"
+
+[[security.sinks]]
+symbol = "class_eval"
+threat = "code_injection"
+cwe = "CWE-95"
+
+[[security.sinks]]
+symbol = "module_eval"
+threat = "code_injection"
+cwe = "CWE-95"
+
+[[security.sinks]]
+symbol = "binding.eval"
+threat = "code_injection"
+cwe = "CWE-95"
+
+[[security.sinks]]
 symbol = "system"
 threat = "command_injection"
 cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "exec"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "spawn"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "`"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "Backtick operator"
+
+[[security.sinks]]
+symbol = "%x"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "Open3.capture3"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "Open3.popen3"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "IO.popen"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "Kernel.open"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "Filename starting with | spawns a process"
+
+[[security.sinks]]
+symbol = "URI.open"
+threat = "ssrf"
+cwe = "CWE-918"
+note = "open-uri; also command injection via | prefix pre-3.0"
 
 [[security.sinks]]
 symbol = "send"
@@ -29,6 +97,104 @@ threat = "unsafe_reflection"
 cwe = "CWE-470"
 
 [[security.sinks]]
+symbol = "public_send"
+threat = "unsafe_reflection"
+cwe = "CWE-470"
+note = "Restricts to public methods but still dangerous"
+
+[[security.sinks]]
+symbol = "Object.const_get"
+threat = "unsafe_reflection"
+cwe = "CWE-470"
+
+[[security.sinks]]
+symbol = "method"
+threat = "unsafe_reflection"
+cwe = "CWE-470"
+note = "When method name is caller-controlled"
+
+[[security.sinks]]
 symbol = "Marshal.load"
 threat = "deserialization"
 cwe = "CWE-502"
+
+[[security.sinks]]
+symbol = "Marshal.restore"
+threat = "deserialization"
+cwe = "CWE-502"
+
+[[security.sinks]]
+symbol = "YAML.load"
+threat = "deserialization"
+cwe = "CWE-502"
+note = "Pre-Psych 4 default; use YAML.safe_load"
+
+[[security.sinks]]
+symbol = "YAML.unsafe_load"
+threat = "deserialization"
+cwe = "CWE-502"
+
+[[security.sinks]]
+symbol = "Psych.load"
+threat = "deserialization"
+cwe = "CWE-502"
+note = "Pre-Psych 4; safe by default in Psych 4+"
+
+[[security.sinks]]
+symbol = "JSON.load"
+threat = "deserialization"
+cwe = "CWE-502"
+note = "Calls json_create on classes; use JSON.parse"
+
+[[security.sinks]]
+symbol = "File.open"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "File.read"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "File.write"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "IO.read"
+threat = "path_traversal"
+cwe = "CWE-22"
+note = "Also command injection via | prefix"
+
+[[security.sinks]]
+symbol = "Net::HTTP.get"
+threat = "ssrf"
+cwe = "CWE-918"
+
+[[security.sinks]]
+symbol = "Net::HTTP.start"
+threat = "ssrf"
+cwe = "CWE-918"
+
+[[security.sinks]]
+symbol = "Digest::MD5"
+threat = "weak_crypto"
+cwe = "CWE-327"
+
+[[security.sinks]]
+symbol = "Digest::SHA1"
+threat = "weak_crypto"
+cwe = "CWE-327"
+
+[[security.sinks]]
+symbol = "OpenSSL::Cipher.new"
+threat = "weak_crypto"
+cwe = "CWE-327"
+note = "When algorithm is DES, RC4, or ECB mode"
+
+[[security.sinks]]
+symbol = "Random.rand"
+threat = "weak_crypto"
+cwe = "CWE-338"
+note = "Not cryptographically secure; use SecureRandom"


### PR DESCRIPTION
The six languages with the most tool defs each get a sink list covering the standard library danger zones: code eval, OS process spawning, deserialization, XML external entities, file ops with caller-controlled paths, outbound HTTP, weak crypto primitives, unsafe reflection.

169 sinks total: Ruby 35, PHP 32, Java 28, Go 26, Python 24, Node 24. Each carries a threat ID that resolves against `_threats.toml`, a CWE reference, and a note where the dangerous form is a subset of normal use (`subprocess` with `shell=True`, `Kernel.open` with `|` prefix, `text/template` vs `html/template`, etc).

Sources: Bandit's plugin list for Python, gosec rules for Go, Brakeman's check definitions for Ruby, the Semgrep registry standard rulesets for PHP/Java/Node, OWASP cheat sheets for the XML parser configurations. Java gets the JNDI `Naming.lookup` sink that log4shell ran through.

Part of #16