### PR TITLE
Seed stdlib sinks for C#, Rust, Elixir, C, C++, Kotlin, Scala, Swift, Dart, Perl, Lua

### DIFF
--- a/knowledge/c/language.toml
+++ b/knowledge/c/language.toml
@@ -11,3 +11,155 @@ ecosystems = ["c"]
 
 [taxonomy]
 role = ["language"]
+
+[[security.sinks]]
+symbol = "system"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "popen"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "execvp"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "When filename or argv from caller input"
+
+[[security.sinks]]
+symbol = "execlp"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "execl"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "gets"
+threat = "code_injection"
+cwe = "CWE-120"
+note = "Removed in C11; no bounds checking"
+
+[[security.sinks]]
+symbol = "strcpy"
+threat = "code_injection"
+cwe = "CWE-120"
+note = "No bounds checking; use strncpy or strlcpy"
+
+[[security.sinks]]
+symbol = "strcat"
+threat = "code_injection"
+cwe = "CWE-120"
+
+[[security.sinks]]
+symbol = "sprintf"
+threat = "code_injection"
+cwe = "CWE-120"
+note = "No bounds checking; use snprintf"
+
+[[security.sinks]]
+symbol = "vsprintf"
+threat = "code_injection"
+cwe = "CWE-120"
+
+[[security.sinks]]
+symbol = "scanf"
+threat = "code_injection"
+cwe = "CWE-120"
+note = "With %s and no width limit"
+
+[[security.sinks]]
+symbol = "printf"
+threat = "code_injection"
+cwe = "CWE-134"
+note = "When format string is caller-controlled"
+
+[[security.sinks]]
+symbol = "fprintf"
+threat = "code_injection"
+cwe = "CWE-134"
+
+[[security.sinks]]
+symbol = "syslog"
+threat = "code_injection"
+cwe = "CWE-134"
+note = "Format string vulnerability"
+
+[[security.sinks]]
+symbol = "tmpnam"
+threat = "path_traversal"
+cwe = "CWE-377"
+note = "Race condition; use mkstemp"
+
+[[security.sinks]]
+symbol = "mktemp"
+threat = "path_traversal"
+cwe = "CWE-377"
+
+[[security.sinks]]
+symbol = "fopen"
+threat = "path_traversal"
+cwe = "CWE-22"
+note = "When filename is caller-controlled"
+
+[[security.sinks]]
+symbol = "open"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "access"
+threat = "path_traversal"
+cwe = "CWE-367"
+note = "TOCTOU race between check and use"
+
+[[security.sinks]]
+symbol = "rand"
+threat = "weak_crypto"
+cwe = "CWE-338"
+note = "Not cryptographically secure"
+
+[[security.sinks]]
+symbol = "srand"
+threat = "weak_crypto"
+cwe = "CWE-338"
+note = "Predictable seeding with time(NULL)"
+
+[[security.sinks]]
+symbol = "atoi"
+threat = "code_injection"
+cwe = "CWE-190"
+note = "No error checking; undefined on overflow"
+
+[[security.sinks]]
+symbol = "alloca"
+threat = "code_injection"
+cwe = "CWE-770"
+note = "Stack allocation with caller-controlled size"
+
+[[security.sinks]]
+symbol = "free"
+threat = "code_injection"
+cwe = "CWE-415"
+note = "Double-free when pointer reused without null"
+
+[[security.sinks]]
+symbol = "memcpy"
+threat = "code_injection"
+cwe = "CWE-120"
+note = "When size argument is caller-controlled"
+
+[[security.sinks]]
+symbol = "memmove"
+threat = "code_injection"
+cwe = "CWE-120"
+
+[[security.sinks]]
+symbol = "realloc"
+threat = "code_injection"
+cwe = "CWE-415"
+note = "Returns null on failure; original freed"

--- a/knowledge/cpp/language.toml
+++ b/knowledge/cpp/language.toml
@@ -11,3 +11,98 @@ ecosystems = ["cpp"]
 
 [taxonomy]
 role = ["language"]
+
+[[security.sinks]]
+symbol = "std::system"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "popen"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "C library function, commonly used in C++"
+
+[[security.sinks]]
+symbol = "gets"
+threat = "code_injection"
+cwe = "CWE-120"
+note = "Removed in C++14"
+
+[[security.sinks]]
+symbol = "strcpy"
+threat = "code_injection"
+cwe = "CWE-120"
+
+[[security.sinks]]
+symbol = "strcat"
+threat = "code_injection"
+cwe = "CWE-120"
+
+[[security.sinks]]
+symbol = "sprintf"
+threat = "code_injection"
+cwe = "CWE-120"
+
+[[security.sinks]]
+symbol = "scanf"
+threat = "code_injection"
+cwe = "CWE-120"
+note = "With %s and no width limit"
+
+[[security.sinks]]
+symbol = "printf"
+threat = "code_injection"
+cwe = "CWE-134"
+note = "Format string with caller input"
+
+[[security.sinks]]
+symbol = "tmpnam"
+threat = "path_traversal"
+cwe = "CWE-377"
+
+[[security.sinks]]
+symbol = "std::tmpnam"
+threat = "path_traversal"
+cwe = "CWE-377"
+
+[[security.sinks]]
+symbol = "rand"
+threat = "weak_crypto"
+cwe = "CWE-338"
+note = "Use std::random_device or platform CSPRNG"
+
+[[security.sinks]]
+symbol = "memcpy"
+threat = "code_injection"
+cwe = "CWE-120"
+note = "When size from caller input"
+
+[[security.sinks]]
+symbol = "alloca"
+threat = "code_injection"
+cwe = "CWE-770"
+
+[[security.sinks]]
+symbol = "reinterpret_cast"
+threat = "code_injection"
+cwe = "CWE-119"
+note = "Bypasses type system"
+
+[[security.sinks]]
+symbol = "const_cast"
+threat = "code_injection"
+cwe = "CWE-119"
+note = "Modifying originally-const data is UB"
+
+[[security.sinks]]
+symbol = "new"
+threat = "code_injection"
+cwe = "CWE-770"
+note = "Without nothrow; unchecked allocation"
+
+[[security.sinks]]
+symbol = "delete"
+threat = "code_injection"
+cwe = "CWE-415"
+note = "Double-delete or delete of stack pointer"

--- a/knowledge/csharp/language.toml
+++ b/knowledge/csharp/language.toml
@@ -11,3 +11,199 @@ ecosystems = ["csharp"]
 
 [taxonomy]
 role = ["language"]
+
+[[security.sinks]]
+symbol = "Process.Start"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "ProcessStartInfo"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "When FileName or Arguments are caller-controlled"
+
+[[security.sinks]]
+symbol = "BinaryFormatter.Deserialize"
+threat = "deserialization"
+cwe = "CWE-502"
+note = "Obsolete in .NET 5+; gadget chains via ysoserial.net"
+
+[[security.sinks]]
+symbol = "BinaryFormatter.Serialize"
+threat = "deserialization"
+cwe = "CWE-502"
+note = "Paired with Deserialize for untrusted roundtrip"
+
+[[security.sinks]]
+symbol = "LosFormatter.Deserialize"
+threat = "deserialization"
+cwe = "CWE-502"
+note = "ViewState formatter; RCE via gadget chains"
+
+[[security.sinks]]
+symbol = "ObjectStateFormatter.Deserialize"
+threat = "deserialization"
+cwe = "CWE-502"
+
+[[security.sinks]]
+symbol = "SoapFormatter.Deserialize"
+threat = "deserialization"
+cwe = "CWE-502"
+
+[[security.sinks]]
+symbol = "NetDataContractSerializer.ReadObject"
+threat = "deserialization"
+cwe = "CWE-502"
+note = "Type info in payload; gadget chains"
+
+[[security.sinks]]
+symbol = "DataContractSerializer"
+threat = "deserialization"
+cwe = "CWE-502"
+note = "When knownTypes includes dangerous types or resolver is open"
+
+[[security.sinks]]
+symbol = "JavaScriptSerializer.Deserialize"
+threat = "deserialization"
+cwe = "CWE-502"
+note = "With SimpleTypeResolver or JavaScriptTypeResolver"
+
+[[security.sinks]]
+symbol = "XmlSerializer"
+threat = "deserialization"
+cwe = "CWE-502"
+note = "When type parameter is caller-controlled"
+
+[[security.sinks]]
+symbol = "JsonConvert.DeserializeObject"
+threat = "deserialization"
+cwe = "CWE-502"
+note = "Newtonsoft with TypeNameHandling enabled"
+
+[[security.sinks]]
+symbol = "Assembly.Load"
+threat = "code_injection"
+cwe = "CWE-470"
+note = "When assembly name is caller-controlled"
+
+[[security.sinks]]
+symbol = "Assembly.LoadFrom"
+threat = "code_injection"
+cwe = "CWE-470"
+
+[[security.sinks]]
+symbol = "Assembly.LoadFile"
+threat = "code_injection"
+cwe = "CWE-470"
+
+[[security.sinks]]
+symbol = "Activator.CreateInstance"
+threat = "unsafe_reflection"
+cwe = "CWE-470"
+note = "When type name is caller-controlled"
+
+[[security.sinks]]
+symbol = "Type.GetType"
+threat = "unsafe_reflection"
+cwe = "CWE-470"
+note = "When type string is caller-controlled"
+
+[[security.sinks]]
+symbol = "Type.InvokeMember"
+threat = "unsafe_reflection"
+cwe = "CWE-470"
+
+[[security.sinks]]
+symbol = "XmlDocument.Load"
+threat = "xxe"
+cwe = "CWE-611"
+note = "Without XmlResolver = null; safe by default in .NET 4.5.2+"
+
+[[security.sinks]]
+symbol = "XmlTextReader"
+threat = "xxe"
+cwe = "CWE-611"
+note = "DtdProcessing.Parse default pre-.NET 4.0"
+
+[[security.sinks]]
+symbol = "XsltCompiledTransform.Load"
+threat = "xxe"
+cwe = "CWE-611"
+
+[[security.sinks]]
+symbol = "SqlCommand"
+threat = "sql_injection"
+cwe = "CWE-89"
+note = "When CommandText built via string concat; use Parameters.Add"
+
+[[security.sinks]]
+symbol = "SqlDataAdapter"
+threat = "sql_injection"
+cwe = "CWE-89"
+
+[[security.sinks]]
+symbol = "File.ReadAllText"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "File.WriteAllText"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "File.Open"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "FileStream"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "Directory.GetFiles"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "HttpClient.GetAsync"
+threat = "ssrf"
+cwe = "CWE-918"
+
+[[security.sinks]]
+symbol = "HttpClient.PostAsync"
+threat = "ssrf"
+cwe = "CWE-918"
+
+[[security.sinks]]
+symbol = "WebClient.DownloadString"
+threat = "ssrf"
+cwe = "CWE-918"
+
+[[security.sinks]]
+symbol = "Response.Redirect"
+threat = "open_redirect"
+cwe = "CWE-601"
+
+[[security.sinks]]
+symbol = "MD5.Create"
+threat = "weak_crypto"
+cwe = "CWE-327"
+
+[[security.sinks]]
+symbol = "SHA1.Create"
+threat = "weak_crypto"
+cwe = "CWE-327"
+
+[[security.sinks]]
+symbol = "DES.Create"
+threat = "weak_crypto"
+cwe = "CWE-327"
+
+[[security.sinks]]
+symbol = "Random"
+threat = "weak_crypto"
+cwe = "CWE-338"
+note = "System.Random; use RandomNumberGenerator for security"

--- a/knowledge/dart/language.toml
+++ b/knowledge/dart/language.toml
@@ -12,3 +12,74 @@ ecosystems = ["dart"]
 
 [taxonomy]
 role = ["language"]
+
+[[security.sinks]]
+symbol = "Process.run"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "When executable or args from caller input"
+
+[[security.sinks]]
+symbol = "Process.start"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "Process.runSync"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "File.readAsString"
+threat = "path_traversal"
+cwe = "CWE-22"
+note = "dart:io"
+
+[[security.sinks]]
+symbol = "File.readAsBytes"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "File.writeAsString"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "File.writeAsBytes"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "Directory.list"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "HttpClient.getUrl"
+threat = "ssrf"
+cwe = "CWE-918"
+note = "dart:io HttpClient"
+
+[[security.sinks]]
+symbol = "HttpClient.postUrl"
+threat = "ssrf"
+cwe = "CWE-918"
+
+[[security.sinks]]
+symbol = "http.get"
+threat = "ssrf"
+cwe = "CWE-918"
+note = "package:http convenience function"
+
+[[security.sinks]]
+symbol = "Isolate.spawnUri"
+threat = "code_injection"
+cwe = "CWE-470"
+note = "When URI is caller-controlled"
+
+[[security.sinks]]
+symbol = "Random"
+threat = "weak_crypto"
+cwe = "CWE-338"
+note = "dart:math Random; use Random.secure() for security"

--- a/knowledge/elixir/language.toml
+++ b/knowledge/elixir/language.toml
@@ -12,3 +12,98 @@ ecosystems = ["elixir"]
 
 [taxonomy]
 role = ["language"]
+
+[[security.sinks]]
+symbol = "Code.eval_string"
+threat = "code_injection"
+cwe = "CWE-95"
+
+[[security.sinks]]
+symbol = "Code.eval_quoted"
+threat = "code_injection"
+cwe = "CWE-95"
+
+[[security.sinks]]
+symbol = "Code.eval_file"
+threat = "code_injection"
+cwe = "CWE-95"
+
+[[security.sinks]]
+symbol = ":os.cmd"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "Erlang interop; passes string to system shell"
+
+[[security.sinks]]
+symbol = "System.cmd"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "Argv form is safer; shell_cmd is not"
+
+[[security.sinks]]
+symbol = "System.shell"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "Invokes system shell"
+
+[[security.sinks]]
+symbol = "Port.open"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "With {:spawn, cmd} or {:spawn_executable, path}"
+
+[[security.sinks]]
+symbol = "String.to_atom"
+threat = "dos"
+cwe = "CWE-400"
+note = "Atoms are never garbage collected; exhaustion at ~1M"
+
+[[security.sinks]]
+symbol = "String.to_existing_atom"
+threat = "dos"
+cwe = "CWE-400"
+note = "Safer but still probes the atom table"
+
+[[security.sinks]]
+symbol = ":erlang.binary_to_term"
+threat = "deserialization"
+cwe = "CWE-502"
+note = "Without [:safe]; can create atoms and funs"
+
+[[security.sinks]]
+symbol = ":erlang.list_to_atom"
+threat = "dos"
+cwe = "CWE-400"
+
+[[security.sinks]]
+symbol = "File.read"
+threat = "path_traversal"
+cwe = "CWE-22"
+note = "When path is caller-controlled"
+
+[[security.sinks]]
+symbol = "File.read!"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "File.write"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "File.stream!"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = ":httpc.request"
+threat = "ssrf"
+cwe = "CWE-918"
+note = "Erlang HTTP client"
+
+[[security.sinks]]
+symbol = "EEx.eval_string"
+threat = "ssti"
+cwe = "CWE-1336"
+note = "When template string is caller-controlled"

--- a/knowledge/kotlin/language.toml
+++ b/knowledge/kotlin/language.toml
@@ -12,3 +12,70 @@ ecosystems = ["kotlin"]
 
 [taxonomy]
 role = ["language"]
+
+[[security.sinks]]
+symbol = "Runtime.getRuntime().exec"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "JVM; same as Java"
+
+[[security.sinks]]
+symbol = "ProcessBuilder"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "ObjectInputStream.readObject"
+threat = "deserialization"
+cwe = "CWE-502"
+note = "JVM native serialization"
+
+[[security.sinks]]
+symbol = "Class.forName"
+threat = "unsafe_reflection"
+cwe = "CWE-470"
+note = "When class name is caller-controlled"
+
+[[security.sinks]]
+symbol = "KClass.createInstance"
+threat = "unsafe_reflection"
+cwe = "CWE-470"
+
+[[security.sinks]]
+symbol = "ScriptEngine.eval"
+threat = "code_injection"
+cwe = "CWE-95"
+note = "javax.script"
+
+[[security.sinks]]
+symbol = "File.readText"
+threat = "path_traversal"
+cwe = "CWE-22"
+note = "kotlin.io"
+
+[[security.sinks]]
+symbol = "File.writeText"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "Path.readText"
+threat = "path_traversal"
+cwe = "CWE-22"
+note = "kotlin.io.path"
+
+[[security.sinks]]
+symbol = "URL.readText"
+threat = "ssrf"
+cwe = "CWE-918"
+
+[[security.sinks]]
+symbol = "java.net.http.HttpClient.send"
+threat = "ssrf"
+cwe = "CWE-918"
+
+[[security.sinks]]
+symbol = "Random"
+threat = "weak_crypto"
+cwe = "CWE-338"
+note = "kotlin.random.Random; use java.security.SecureRandom"

--- a/knowledge/lua/language.toml
+++ b/knowledge/lua/language.toml
@@ -11,3 +11,66 @@ ecosystems = ["lua"]
 
 [taxonomy]
 role = ["language"]
+
+[[security.sinks]]
+symbol = "loadstring"
+threat = "code_injection"
+cwe = "CWE-95"
+note = "Lua 5.1; compiles and returns string as function"
+
+[[security.sinks]]
+symbol = "load"
+threat = "code_injection"
+cwe = "CWE-95"
+note = "Lua 5.2+; replaces loadstring"
+
+[[security.sinks]]
+symbol = "dofile"
+threat = "code_injection"
+cwe = "CWE-95"
+note = "Loads and executes a Lua file"
+
+[[security.sinks]]
+symbol = "loadfile"
+threat = "code_injection"
+cwe = "CWE-95"
+note = "Compiles file without executing"
+
+[[security.sinks]]
+symbol = "os.execute"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "io.popen"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "io.open"
+threat = "path_traversal"
+cwe = "CWE-22"
+note = "When filename is caller-controlled"
+
+[[security.sinks]]
+symbol = "io.input"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "require"
+threat = "code_injection"
+cwe = "CWE-470"
+note = "When module name is caller-controlled; searches package.path"
+
+[[security.sinks]]
+symbol = "debug.getinfo"
+threat = "code_injection"
+cwe = "CWE-200"
+note = "Leaks internal state; the debug library should be disabled in sandboxes"
+
+[[security.sinks]]
+symbol = "debug.sethook"
+threat = "code_injection"
+cwe = "CWE-94"
+note = "Can intercept all function calls"

--- a/knowledge/perl/language.toml
+++ b/knowledge/perl/language.toml
@@ -11,3 +11,89 @@ ecosystems = ["perl"]
 
 [taxonomy]
 role = ["language"]
+
+[[security.sinks]]
+symbol = "eval"
+threat = "code_injection"
+cwe = "CWE-95"
+note = "eval STRING executes arbitrary Perl"
+
+[[security.sinks]]
+symbol = "system"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "exec"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "`"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "Backtick operator"
+
+[[security.sinks]]
+symbol = "qx"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "Same as backticks"
+
+[[security.sinks]]
+symbol = "open"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "Two-arg form or | prefix; use three-arg open"
+
+[[security.sinks]]
+symbol = "do"
+threat = "code_injection"
+cwe = "CWE-95"
+note = "do FILE executes Perl file"
+
+[[security.sinks]]
+symbol = "require"
+threat = "code_injection"
+cwe = "CWE-470"
+note = "When module name is caller-controlled"
+
+[[security.sinks]]
+symbol = "Storable::thaw"
+threat = "deserialization"
+cwe = "CWE-502"
+note = "Storable module; arbitrary object instantiation"
+
+[[security.sinks]]
+symbol = "Storable::retrieve"
+threat = "deserialization"
+cwe = "CWE-502"
+
+[[security.sinks]]
+symbol = "YAML::Load"
+threat = "deserialization"
+cwe = "CWE-502"
+note = "YAML.pm; allows blessed objects"
+
+[[security.sinks]]
+symbol = "XML::Simple"
+threat = "xxe"
+cwe = "CWE-611"
+note = "Expat backend resolves entities; use XML::LibXML with no_network"
+
+[[security.sinks]]
+symbol = "DBI->prepare"
+threat = "sql_injection"
+cwe = "CWE-89"
+note = "When query built via string interpolation; use placeholders"
+
+[[security.sinks]]
+symbol = "srand"
+threat = "weak_crypto"
+cwe = "CWE-338"
+note = "Predictable seeding"
+
+[[security.sinks]]
+symbol = "rand"
+threat = "weak_crypto"
+cwe = "CWE-338"

--- a/knowledge/rust/language.toml
+++ b/knowledge/rust/language.toml
@@ -12,3 +12,76 @@ ecosystems = ["rust"]
 
 [taxonomy]
 role = ["language"]
+
+[[security.sinks]]
+symbol = "Command::new"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "When program or args built from caller input"
+
+[[security.sinks]]
+symbol = "Command::arg"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "std::process::exit"
+threat = "dos"
+cwe = "CWE-400"
+note = "Abrupt termination without cleanup"
+
+[[security.sinks]]
+symbol = "transmute"
+threat = "code_injection"
+cwe = "CWE-119"
+note = "Reinterprets memory; any type to any type"
+
+[[security.sinks]]
+symbol = "from_raw_parts"
+threat = "code_injection"
+cwe = "CWE-119"
+note = "slice::from_raw_parts trusts pointer and length"
+
+[[security.sinks]]
+symbol = "std::ptr::read"
+threat = "code_injection"
+cwe = "CWE-119"
+note = "Reads arbitrary memory"
+
+[[security.sinks]]
+symbol = "std::ptr::write"
+threat = "code_injection"
+cwe = "CWE-119"
+
+[[security.sinks]]
+symbol = "CStr::from_ptr"
+threat = "code_injection"
+cwe = "CWE-119"
+note = "Trusts pointer to be nul-terminated"
+
+[[security.sinks]]
+symbol = "File::open"
+threat = "path_traversal"
+cwe = "CWE-22"
+note = "When path is caller-controlled"
+
+[[security.sinks]]
+symbol = "fs::read"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "fs::write"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "fs::read_to_string"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "reqwest::get"
+threat = "ssrf"
+cwe = "CWE-918"
+note = "In reqwest crate, not stdlib; listed since nearly universal"

--- a/knowledge/scala/language.toml
+++ b/knowledge/scala/language.toml
@@ -12,3 +12,66 @@ ecosystems = ["scala"]
 
 [taxonomy]
 role = ["language"]
+
+[[security.sinks]]
+symbol = "Process"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "scala.sys.process.Process(string).!"
+
+[[security.sinks]]
+symbol = ".!"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "stringToProcess implicit; runs via shell"
+
+[[security.sinks]]
+symbol = ".!!"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "Captures stdout"
+
+[[security.sinks]]
+symbol = ".lazyLines"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "Runtime.getRuntime().exec"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "JVM interop"
+
+[[security.sinks]]
+symbol = "ObjectInputStream.readObject"
+threat = "deserialization"
+cwe = "CWE-502"
+note = "JVM native serialization"
+
+[[security.sinks]]
+symbol = "Source.fromURL"
+threat = "ssrf"
+cwe = "CWE-918"
+note = "scala.io.Source"
+
+[[security.sinks]]
+symbol = "Source.fromFile"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "XML.load"
+threat = "xxe"
+cwe = "CWE-611"
+note = "scala.xml.XML.load; default parser resolves entities"
+
+[[security.sinks]]
+symbol = "XML.loadFile"
+threat = "xxe"
+cwe = "CWE-611"
+
+[[security.sinks]]
+symbol = "Random"
+threat = "weak_crypto"
+cwe = "CWE-338"
+note = "scala.util.Random; use java.security.SecureRandom"

--- a/knowledge/swift/language.toml
+++ b/knowledge/swift/language.toml
@@ -12,3 +12,96 @@ ecosystems = ["swift"]
 
 [taxonomy]
 role = ["language"]
+
+[[security.sinks]]
+symbol = "Process"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "Foundation.Process (was NSTask)"
+
+[[security.sinks]]
+symbol = "NSTask"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "Legacy name for Process"
+
+[[security.sinks]]
+symbol = "NSKeyedUnarchiver.unarchiveObject"
+threat = "deserialization"
+cwe = "CWE-502"
+note = "Instantiates arbitrary classes; use unarchivedObject(ofClass:)"
+
+[[security.sinks]]
+symbol = "NSKeyedUnarchiver.unarchiveTopLevelObjectWithData"
+threat = "deserialization"
+cwe = "CWE-502"
+
+[[security.sinks]]
+symbol = "NSCoding"
+threat = "deserialization"
+cwe = "CWE-502"
+note = "Protocol enabling arbitrary object deserialization"
+
+[[security.sinks]]
+symbol = "FileManager.contents"
+threat = "path_traversal"
+cwe = "CWE-22"
+note = "When path from user input"
+
+[[security.sinks]]
+symbol = "FileManager.createFile"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "String.init(contentsOfFile:)"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "Data.init(contentsOf:)"
+threat = "path_traversal"
+cwe = "CWE-22"
+note = "Also accepts URLs (SSRF)"
+
+[[security.sinks]]
+symbol = "URLSession.dataTask"
+threat = "ssrf"
+cwe = "CWE-918"
+note = "When URL is caller-controlled"
+
+[[security.sinks]]
+symbol = "URLSession.shared.data"
+threat = "ssrf"
+cwe = "CWE-918"
+note = "async/await form"
+
+[[security.sinks]]
+symbol = "NSExpression"
+threat = "code_injection"
+cwe = "CWE-95"
+note = "Evaluates expressions; constrained but gadgets exist"
+
+[[security.sinks]]
+symbol = "NSPredicate"
+threat = "code_injection"
+cwe = "CWE-95"
+note = "Format string injection with caller input"
+
+[[security.sinks]]
+symbol = "WKWebView.loadHTMLString"
+threat = "xss"
+cwe = "CWE-79"
+note = "Renders HTML in WebKit"
+
+[[security.sinks]]
+symbol = "UIWebView.loadHTMLString"
+threat = "xss"
+cwe = "CWE-79"
+note = "Deprecated; same risk"
+
+[[security.sinks]]
+symbol = "XMLParser"
+threat = "xxe"
+cwe = "CWE-611"
+note = "Foundation; resolves external entities by default"


### PR DESCRIPTION
188 sinks across the next tier of 11 languages, building on the six from #24.

C# (36) gets the .NET deserialization surface (BinaryFormatter, LosFormatter, NetDataContractSerializer, JavaScriptSerializer with TypeResolver), XXE via XmlDocument/XmlTextReader, SqlCommand injection, and Assembly.Load/Activator.CreateInstance reflection. C (27) and C++ (17) get buffer overflow classics (gets, strcpy, sprintf, scanf %s), format string sinks (printf with caller format), tmpnam/mktemp TOCTOU, and the memory misuse patterns (double-free, unchecked alloca). Elixir (17) gets Code.eval_string, :os.cmd/:erlang interop, atom exhaustion via String.to_atom, and :erlang.binary_to_term without :safe. Kotlin (12) and Scala (11) inherit JVM surface with language-specific entry points (Scala's string-to-process implicit .!, Kotlin's kotlin.io.path). Swift (16) gets NSKeyedUnarchiver deserialization, NSPredicate/NSExpression injection, WKWebView XSS, and XMLParser XXE. Perl (15) gets two-arg open with | pipe injection and Storable::thaw deserialization. Lua (11) gets loadstring/load and notes that the debug library should be disabled in sandboxes. Rust (13) is mostly unsafe pointer operations plus Command::new.

17 of 53 language defs now carry sinks, covering the ecosystems where projects actually appear in practice. The remaining 36 (Ada, COBOL, Gleam, Roc, etc) are left for later.

Closes #29