### PR TITLE
Fill sinks for tools where threat-model fires but sinks was empty

### DIFF
--- a/knowledge/node/adonisjs.toml
+++ b/knowledge/node/adonisjs.toml
@@ -23,3 +23,90 @@ role = ["framework"]
 function = ["api-development", "templating", "data-mapping", "authentication"]
 layer = ["backend", "full-stack"]
 domain = ["web-development"]
+
+[[security.sinks]]
+symbol = "{{{"
+threat = "xss"
+cwe = "CWE-79"
+note = "Triple-stash unescaped output in Edge templates"
+
+[[security.sinks]]
+symbol = "@!section"
+threat = "xss"
+cwe = "CWE-79"
+note = "Raw section output"
+
+[[security.sinks]]
+symbol = "safe"
+threat = "xss"
+cwe = "CWE-79"
+note = "Edge safe() helper marks content as pre-escaped"
+
+[[security.sinks]]
+symbol = "Database.rawQuery"
+threat = "sql_injection"
+cwe = "CWE-89"
+note = "Raw SQL; use bindings parameter"
+
+[[security.sinks]]
+symbol = ".whereRaw"
+threat = "sql_injection"
+cwe = "CWE-89"
+
+[[security.sinks]]
+symbol = ".joinRaw"
+threat = "sql_injection"
+cwe = "CWE-89"
+
+[[security.sinks]]
+symbol = ".orderByRaw"
+threat = "sql_injection"
+cwe = "CWE-89"
+
+[[security.sinks]]
+symbol = ".havingRaw"
+threat = "sql_injection"
+cwe = "CWE-89"
+
+[[security.sinks]]
+symbol = "Database.from"
+threat = "sql_injection"
+cwe = "CWE-89"
+note = "With raw string; use Knex bindings"
+
+[[security.sinks]]
+symbol = "response.redirect"
+threat = "open_redirect"
+cwe = "CWE-601"
+
+[[security.sinks]]
+symbol = "response.redirect().toPath"
+threat = "open_redirect"
+cwe = "CWE-601"
+
+[[security.sinks]]
+symbol = "response.download"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "response.attachment"
+threat = "path_traversal"
+cwe = "CWE-22"
+
+[[security.sinks]]
+symbol = "auth.use().login"
+threat = "session_fixation"
+cwe = "CWE-384"
+note = "Ensure session regeneration on login"
+
+[[security.sinks]]
+symbol = "Model.create"
+threat = "mass_assignment"
+cwe = "CWE-915"
+note = "Without $fillable or $guarded on the model"
+
+[[security.sinks]]
+symbol = "Model.fill"
+threat = "mass_assignment"
+cwe = "CWE-915"

--- a/knowledge/node/astro.toml
+++ b/knowledge/node/astro.toml
@@ -23,3 +23,33 @@ role = ["framework"]
 function = ["templating", "site-generation"]
 layer = ["frontend", "full-stack"]
 domain = ["web-development", "content-management"]
+
+[[security.sinks]]
+symbol = "set:html"
+threat = "xss"
+cwe = "CWE-79"
+note = "Directive that renders raw HTML without escaping"
+
+[[security.sinks]]
+symbol = "Fragment"
+threat = "xss"
+cwe = "CWE-79"
+note = "set:html on Fragment"
+
+[[security.sinks]]
+symbol = "Astro.redirect"
+threat = "open_redirect"
+cwe = "CWE-601"
+note = "In SSR mode with caller-controlled URL"
+
+[[security.sinks]]
+symbol = "Response.redirect"
+threat = "open_redirect"
+cwe = "CWE-601"
+note = "In API routes/endpoints"
+
+[[security.sinks]]
+symbol = "dangerouslySetInnerHTML"
+threat = "xss"
+cwe = "CWE-79"
+note = "When using React components in Astro"

--- a/knowledge/node/eleventy.toml
+++ b/knowledge/node/eleventy.toml
@@ -24,3 +24,27 @@ role = ["framework"]
 function = ["templating", "site-generation"]
 layer = ["frontend"]
 domain = ["web-development", "content-management"]
+
+[[security.sinks]]
+symbol = "|safe"
+threat = "xss"
+cwe = "CWE-79"
+note = "Nunjucks filter; Eleventy defaults to Nunjucks"
+
+[[security.sinks]]
+symbol = "{{{"
+threat = "xss"
+cwe = "CWE-79"
+note = "Handlebars triple-stash if using Handlebars engine"
+
+[[security.sinks]]
+symbol = "<%-"
+threat = "xss"
+cwe = "CWE-79"
+note = "EJS unescaped output if using EJS engine"
+
+[[security.sinks]]
+symbol = "addShortcode"
+threat = "ssti"
+cwe = "CWE-1336"
+note = "Shortcodes with raw HTML return; developer-controlled not user-controlled usually"

--- a/knowledge/node/ember.toml
+++ b/knowledge/node/ember.toml
@@ -23,3 +23,32 @@ role = ["framework"]
 function = ["templating"]
 layer = ["frontend"]
 domain = ["web-development"]
+
+[[security.sinks]]
+symbol = "{{{"
+threat = "xss"
+cwe = "CWE-79"
+note = "Triple-stash unescaped in Handlebars templates"
+
+[[security.sinks]]
+symbol = "htmlSafe"
+threat = "xss"
+cwe = "CWE-79"
+note = "Ember.String.htmlSafe marks string as pre-escaped"
+
+[[security.sinks]]
+symbol = "SafeString"
+threat = "xss"
+cwe = "CWE-79"
+note = "Handlebars.SafeString"
+
+[[security.sinks]]
+symbol = "transitionTo"
+threat = "open_redirect"
+cwe = "CWE-601"
+note = "When route/URL is caller-controlled"
+
+[[security.sinks]]
+symbol = "replaceWith"
+threat = "open_redirect"
+cwe = "CWE-601"

--- a/knowledge/node/gatsby.toml
+++ b/knowledge/node/gatsby.toml
@@ -23,3 +23,21 @@ role = ["framework"]
 function = ["templating", "site-generation"]
 layer = ["frontend"]
 domain = ["web-development", "content-management"]
+
+[[security.sinks]]
+symbol = "dangerouslySetInnerHTML"
+threat = "xss"
+cwe = "CWE-79"
+note = "React prop; common in Gatsby for CMS HTML"
+
+[[security.sinks]]
+symbol = "createPage"
+threat = "path_traversal"
+cwe = "CWE-22"
+note = "In gatsby-node.js with caller-controlled path"
+
+[[security.sinks]]
+symbol = "graphql"
+threat = "sql_injection"
+cwe = "CWE-89"
+note = "When query variables from URL params without validation"

--- a/knowledge/node/qwik.toml
+++ b/knowledge/node/qwik.toml
@@ -15,3 +15,20 @@ role = ["framework"]
 function = ["templating"]
 layer = ["frontend", "full-stack"]
 domain = ["web-development"]
+
+[[security.sinks]]
+symbol = "dangerouslySetInnerHTML"
+threat = "xss"
+cwe = "CWE-79"
+
+[[security.sinks]]
+symbol = "Element"
+threat = "xss"
+cwe = "CWE-79"
+note = "innerHTML prop on JSX elements"
+
+[[security.sinks]]
+symbol = "useNavigate"
+threat = "open_redirect"
+cwe = "CWE-601"
+note = "When target is caller-controlled"

--- a/knowledge/node/solidjs.toml
+++ b/knowledge/node/solidjs.toml
@@ -15,3 +15,21 @@ role = ["library"]
 function = ["templating"]
 layer = ["frontend"]
 domain = ["web-development"]
+
+[[security.sinks]]
+symbol = "innerHTML"
+threat = "xss"
+cwe = "CWE-79"
+note = "Prop on JSX elements; renders raw HTML"
+
+[[security.sinks]]
+symbol = "Dynamic"
+threat = "xss"
+cwe = "CWE-79"
+note = "When component prop is caller-controlled"
+
+[[security.sinks]]
+symbol = "createEffect"
+threat = "xss"
+cwe = "CWE-79"
+note = "When setting element.innerHTML in effect"


### PR DESCRIPTION
Seven tools carried taxonomy that fired threat mappings but had no \`[[security.sinks]]\`, so \`brief threat-model\` said "this is dangerous" while \`brief sinks\` said nothing to grep for.

AdonisJS (16 sinks) is the biggest — it bundles Edge templates (\`{{{}\`\` triple stash, \`safe()\` helper), Lucid ORM (\`rawQuery\`, \`whereRaw\` etc), redirect helpers, file downloads, session fixation on \`auth.use().login\`, and mass assignment without \`$fillable\`. Astro gets \`set:html\` and \`Astro.redirect\` for SSR mode. Qwik and SolidJS get their \`innerHTML\` equivalents. Ember gets the Handlebars triple-stash and \`htmlSafe\`. Eleventy gets the unescaped forms from its supported engines (Nunjucks \`|safe\`, Handlebars \`{{{\`, EJS \`<%-\`). Gatsby gets \`dangerouslySetInnerHTML\` and notes on \`createPage\` path traversal.

Every tool carrying \`function:templating\` in its taxonomy now has at least one sink.

Closes #30