### PR TITLE
Tighten _threats.toml: feature-flags mapping, LDAP libs, drop dead scraping mapping

### DIFF
--- a/knowledge/_shared/_threats.toml
+++ b/knowledge/_shared/_threats.toml
@@ -149,11 +149,6 @@ threats = ["path_traversal"]
 note = "File operations with caller-controlled paths"
 
 [[mappings]]
-match = ["function:scraping"]
-threats = ["ssrf"]
-note = "Fetches caller-controlled URLs"
-
-[[mappings]]
 match = ["function:http-client"]
 threats = ["ssrf"]
 note = "Outbound HTTP with caller-controlled URLs"
@@ -182,6 +177,11 @@ note = "Spawns OS processes from string arguments"
 match = ["role:framework", "layer:backend"]
 threats = ["xss", "csrf", "open_redirect", "ssrf", "path_traversal", "auth_bypass"]
 note = "Server-side framework handling user-controlled HTTP input"
+
+[[mappings]]
+match = ["function:feature-flags"]
+threats = ["auth_bypass"]
+note = "Feature gates protecting access checks; accidental exposure of flagged-off code paths"
 
 [[mappings]]
 match = ["role:framework", "layer:frontend"]

--- a/knowledge/node/ldapjs.toml
+++ b/knowledge/node/ldapjs.toml
@@ -1,0 +1,28 @@
+[tool]
+name = "ldapjs"
+category = "build"
+homepage = "http://ldapjs.org"
+docs = "http://ldapjs.org"
+repo = "https://github.com/ldapjs/node-ldapjs"
+description = "LDAP client and server for Node.js"
+
+[detect]
+dependencies = ["ldapjs"]
+ecosystems = ["node"]
+
+[taxonomy]
+role = ["library"]
+function = ["authentication"]
+layer = ["backend"]
+
+[[security.sinks]]
+symbol = "client.search"
+threat = "ldap_injection"
+cwe = "CWE-90"
+note = "When filter string built from caller input; use ldapjs filter objects"
+
+[[security.sinks]]
+symbol = "client.bind"
+threat = "ldap_injection"
+cwe = "CWE-90"
+note = "When DN built from caller input"

--- a/knowledge/php/ldap.toml
+++ b/knowledge/php/ldap.toml
@@ -1,0 +1,34 @@
+[tool]
+name = "PHP LDAP"
+category = "build"
+homepage = "https://www.php.net/manual/en/book.ldap.php"
+docs = "https://www.php.net/manual/en/book.ldap.php"
+description = "LDAP extension for PHP"
+
+[detect]
+ecosystems = ["php"]
+
+[detect.file_contains]
+"composer.json" = ["ext-ldap"]
+
+[taxonomy]
+role = ["library"]
+function = ["authentication"]
+layer = ["backend"]
+
+[[security.sinks]]
+symbol = "ldap_search"
+threat = "ldap_injection"
+cwe = "CWE-90"
+note = "When filter built from user input without escaping; use ldap_escape"
+
+[[security.sinks]]
+symbol = "ldap_bind"
+threat = "ldap_injection"
+cwe = "CWE-90"
+note = "When DN built from user input"
+
+[[security.sinks]]
+symbol = "ldap_read"
+threat = "ldap_injection"
+cwe = "CWE-90"

--- a/knowledge/python/ldap3.toml
+++ b/knowledge/python/ldap3.toml
@@ -1,0 +1,27 @@
+[tool]
+name = "ldap3"
+category = "build"
+homepage = "https://ldap3.readthedocs.io"
+docs = "https://ldap3.readthedocs.io"
+repo = "https://github.com/cannatag/ldap3"
+description = "LDAP client library for Python"
+
+[detect]
+dependencies = ["ldap3"]
+ecosystems = ["python"]
+
+[taxonomy]
+role = ["library"]
+function = ["authentication"]
+layer = ["backend"]
+
+[[security.sinks]]
+symbol = "Connection.search"
+threat = "ldap_injection"
+cwe = "CWE-90"
+note = "When search_filter built via string formatting with caller input"
+
+[[security.sinks]]
+symbol = "Connection.extend.standard.modify_password"
+threat = "ldap_injection"
+cwe = "CWE-90"

--- a/knowledge/ruby/net-ldap.toml
+++ b/knowledge/ruby/net-ldap.toml
@@ -1,0 +1,27 @@
+[tool]
+name = "net-ldap"
+category = "build"
+homepage = "https://github.com/ruby-ldap/ruby-net-ldap"
+docs = "https://www.rubydoc.info/gems/net-ldap"
+repo = "https://github.com/ruby-ldap/ruby-net-ldap"
+description = "LDAP client library for Ruby"
+
+[detect]
+dependencies = ["net-ldap"]
+ecosystems = ["ruby"]
+
+[taxonomy]
+role = ["library"]
+function = ["authentication"]
+layer = ["backend"]
+
+[[security.sinks]]
+symbol = "Net::LDAP#search"
+threat = "ldap_injection"
+cwe = "CWE-90"
+note = "When filter built via string interpolation; use Net::LDAP::Filter"
+
+[[security.sinks]]
+symbol = "Net::LDAP#bind_as"
+threat = "ldap_injection"
+cwe = "CWE-90"


### PR DESCRIPTION
Three loose ends from the _threats.toml audit.

Removed the \`function:scraping\` → \`[ssrf]\` mapping since no tool def carries that tag. Re-add when scrapy/beautifulsoup/puppeteer defs land.

Added \`function:feature-flags\` → \`[auth_bypass]\` mapping so Flipper, LaunchDarkly, and Unleash contribute to threat-model. Feature gates protecting access checks are a real auth bypass surface.

Added four LDAP library defs (\`ldap3\` for Python, \`ldapjs\` for Node, \`net-ldap\` for Ruby, PHP LDAP extension) with \`ldap_injection\` sinks so the threat isn't Java-only. Each detected via the dependencies primitive.

Closes #31