### PR TITLE
Detect brief as an introspection tool when scanning itself

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -158,6 +158,7 @@ func (e *Engine) Run() (*brief.Report, error) {
 	report.PackageManagers = e.detectCategory("package_manager")
 	report.Scripts = e.detectScripts()
 	e.detectTools(report)
+	e.detectSelf(abs, report)
 
 	report.Style = e.detectStyle()
 	report.Layout = e.detectLayout()
@@ -196,6 +197,39 @@ func (e *Engine) Run() (*brief.Report, error) {
 	}
 
 	return report, nil
+}
+
+const selfModulePath = "github.com/git-pkgs/brief"
+
+func (e *Engine) detectSelf(root string, report *brief.Report) {
+	data, err := os.ReadFile(filepath.Join(root, "go.mod"))
+	if err != nil {
+		return
+	}
+	for line := range strings.SplitSeq(string(data), "\n") {
+		mod, ok := strings.CutPrefix(strings.TrimSpace(line), "module ")
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(mod) != selfModulePath {
+			return
+		}
+		report.Tools["introspection"] = append(report.Tools["introspection"], brief.Detection{
+			Name:        "brief",
+			Category:    "introspection",
+			Confidence:  brief.ConfidenceHigh,
+			ConfigFiles: []string{"go.mod"},
+			Homepage:    "https://" + selfModulePath,
+			Repo:        "https://" + selfModulePath,
+			Description: "Describes a project's toolchain. You're looking at it.",
+			Command: &brief.Command{
+				Run:    "brief .",
+				Source: brief.SourceKnowledgeBase,
+			},
+		})
+		e.toolsMatched++
+		return
+	}
 }
 
 // buildEcosystemSet populates detectedEcosystems from language results to filter

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -1,6 +1,8 @@
 package detect
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/git-pkgs/brief"
@@ -410,6 +412,31 @@ func TestShouldSkipDir(t *testing.T) {
 		if got := engine.shouldSkipDir(tt.name); got != tt.skip {
 			t.Errorf("shouldSkipDir(%q) = %v, want %v", tt.name, got, tt.skip)
 		}
+	}
+}
+
+func TestDetectSelf(t *testing.T) {
+	dir := t.TempDir()
+	gomod := "module github.com/git-pkgs/brief\n\ngo 1.22.0\n"
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(gomod), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := New(loadKB(t), dir).Run()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertToolDetected(t, r, "introspection", "brief")
+}
+
+func TestDetectSelfNotTriggeredOnOtherGoProjects(t *testing.T) {
+	r, err := New(loadKB(t), "../testdata/go-project").Run()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := r.Tools["introspection"]; ok {
+		t.Error("introspection category should not appear for non-brief go projects")
 	}
 }
 


### PR DESCRIPTION
When `brief` is run against its own source tree (detected via `module github.com/git-pkgs/brief` in `go.mod`), it now reports itself under a new `introspection` tool category with the description "Describes a project's toolchain. You're looking at it."

Triggers only on the exact module path so other Go projects are unaffected.