### PR TITLE
Add outline subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ brief missing [flags] [path]      Show recommended tooling gaps
 brief threat-model [flags] [path] Threat categories implied by detected stack
 brief sinks [flags] [path]        Dangerous functions in detected tools
 brief enrich [flags] [path]       Detect and enrich with external data
+brief outline [flags] [path|url]  Pack source tree into one document for an LLM
 brief list tools                  All tools in the knowledge base
 brief list ecosystems             Supported ecosystems
 brief schema                      JSON output schema
@@ -228,6 +229,20 @@ Ruby:
 Language definitions carry stdlib sinks (eval, system, pickle.loads, etc). Frameworks carry their own (html_safe, dangerouslySetInnerHTML, redirect_to). ORMs carry raw query escape hatches (find_by_sql, $queryRawUnsafe, Arel.sql). Notes indicate when only some forms of a method are dangerous.
 
 The sink data covers 17 languages, 28 web frameworks, 17 ORMs, 15 HTTP clients, 13 template engines, 10 auth libraries, and more. The knowledge base carries over 700 sinks total.
+
+## Outline
+
+`brief outline` produces a token-friendly summary of a codebase for handing to an LLM. It packs the source tree into a single markdown document: a directory tree followed by each file's content, with function and method bodies stripped so only signatures, types, comments and imports remain. The result is typically a quarter the size of the raw source while keeping enough structure for a model to reason about the code. Files in unsupported languages are included verbatim. Body stripping uses tree-sitter via [git-pkgs/outline](https://github.com/git-pkgs/outline) and currently covers 35 languages.
+
+```
+brief outline .
+brief outline -xml .
+brief outline -full .                          Keep full bodies
+brief outline -ignore "docs/,*.md" .
+brief outline github.com/git-pkgs/gitignore
+```
+
+`.gitignore` is honoured at every level along with a built-in skip list (vendored deps, build output, lockfiles). Binary files and files over 1MB are listed in the tree but omitted from the body; tune with `-max-file-size` and `-max-files`.
 
 ## Enrichment
 

--- a/cmd/brief/main.go
+++ b/cmd/brief/main.go
@@ -51,6 +51,9 @@ func main() {
 		case "sinks":
 			cmdSinks(os.Args[2:])
 			return
+		case "outline":
+			cmdOutline(os.Args[2:])
+			return
 		}
 	}
 

--- a/cmd/brief/outline.go
+++ b/cmd/brief/outline.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"runtime/debug"
+	"strings"
+
+	"github.com/git-pkgs/brief/remote"
+	"github.com/git-pkgs/outline"
+)
+
+func cmdOutline(args []string) {
+	// Re-enable GC: outline parses every source file via tree-sitter, which
+	// allocates substantial arena memory per file. Without GC the pooled
+	// arenas accumulate unboundedly across thousands of files.
+	const defaultGCPercent = 100
+	debug.SetGCPercent(defaultGCPercent)
+
+	fs := flag.NewFlagSet("brief outline", flag.ExitOnError)
+	xmlFlag := fs.Bool("xml", false, "Output XML instead of markdown")
+	full := fs.Bool("full", false, "Include full file contents (no body stripping)")
+	ignore := fs.String("ignore", "", "Additional ignore patterns, comma-separated")
+	maxFileSize := fs.Int64("max-file-size", 0, "Skip files larger than this many bytes (default 1MB)")
+	maxFiles := fs.Int("max-files", 0, "Stop after this many files (default 10000)")
+	keep := fs.Bool("keep", false, "Keep downloaded remote source")
+	depth := fs.Int("depth", -1, "Git clone depth (0 = full clone, default shallow)")
+	dir := fs.String("dir", "", "Directory to clone remote source into")
+	_ = fs.Parse(args)
+
+	path := "."
+	if fs.NArg() > 0 {
+		path = fs.Arg(0)
+	}
+
+	src, err := remote.Resolve(context.Background(), path, remote.Options{
+		Keep:  *keep,
+		Depth: *depth,
+		Dir:   *dir,
+	})
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	opts := outline.Options{
+		Compress:    !*full,
+		MaxFileSize: *maxFileSize,
+		MaxFiles:    *maxFiles,
+	}
+	if *ignore != "" {
+		opts.Ignore = strings.Split(*ignore, ",")
+	}
+
+	code := runOutline(src.Dir, opts, *xmlFlag)
+	src.Cleanup()
+	os.Exit(code)
+}
+
+func runOutline(dir string, opts outline.Options, xmlOut bool) int {
+	r, err := outline.Pack(dir, opts)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+
+	if xmlOut {
+		err = r.XML(os.Stdout)
+	} else {
+		err = r.Markdown(os.Stdout)
+	}
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "error writing output: %v\n", err)
+		return 1
+	}
+	return 0
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/git-pkgs/forge v0.5.0
 	github.com/git-pkgs/licensecheck v0.4.1
 	github.com/git-pkgs/manifests v0.4.3
+	github.com/git-pkgs/outline v0.1.2
 	github.com/git-pkgs/purl v0.1.12
 	github.com/git-pkgs/registries v0.6.0
 	github.com/git-pkgs/spdx v0.1.3
@@ -78,6 +79,7 @@ require (
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/fzipp/gocyclo v0.6.0 // indirect
 	github.com/ghostiam/protogetter v0.3.20 // indirect
+	github.com/git-pkgs/gitignore v1.1.2 // indirect
 	github.com/git-pkgs/packageurl-go v0.3.1 // indirect
 	github.com/git-pkgs/pom v0.1.4 // indirect
 	github.com/git-pkgs/vers v0.2.5 // indirect
@@ -159,6 +161,7 @@ require (
 	github.com/nishanths/predeclared v0.2.2 // indirect
 	github.com/nunnatsa/ginkgolinter v0.23.0 // indirect
 	github.com/oapi-codegen/runtime v1.1.2 // indirect
+	github.com/odvcencio/gotreesitter v0.15.3 // indirect
 	github.com/package-url/packageurl-go v0.1.6 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -194,10 +194,14 @@ github.com/git-pkgs/enrichment v0.2.2 h1:vaQu5vs3tjQB5JI0gzBrUCynUc9z3l5byPhgKFa
 github.com/git-pkgs/enrichment v0.2.2/go.mod h1:5JWGmlHWcv5HQHUrctcpnRUNpEF5VAixD2z4zvqKejs=
 github.com/git-pkgs/forge v0.5.0 h1:o7SS9H+IG8Z4fqcwc+yNFPOx9v5gfjq5Lpd3O5PIIo0=
 github.com/git-pkgs/forge v0.5.0/go.mod h1:kDdoXhuutvUe+r2ILoqvNBTXPE+5a5SofKiJmhfqni0=
+github.com/git-pkgs/gitignore v1.1.2 h1:rWifE6a4QcnawUQzX6y/cFqX3LRD0y0mjtGaU5NWpek=
+github.com/git-pkgs/gitignore v1.1.2/go.mod h1:Lr0XwhbvP071rZF/zIIhkY1gEhFDoWHH91lngwLpeUg=
 github.com/git-pkgs/licensecheck v0.4.1 h1:b5ilmpIpgeeewBFjdhJ4W7jvwPIFsYQ7ujZma7sli6k=
 github.com/git-pkgs/licensecheck v0.4.1/go.mod h1:cfFO7yHHPeuXsoODHBWyevajH2yWcbfkIFELyG3ZpU0=
 github.com/git-pkgs/manifests v0.4.3 h1:bjwWQiJ2Xqih/PjBCyJtt2bx9WqKjMq/YxoNSDUE8bQ=
 github.com/git-pkgs/manifests v0.4.3/go.mod h1:Jvvua5FVNvEFx+I5QQ8vbhHAz11gsMfrbocFCX/BvVo=
+github.com/git-pkgs/outline v0.1.2 h1:UY/iFrlnA3n445Oi3RL1WWrjcKsY5PqzT/JMEkN0mbM=
+github.com/git-pkgs/outline v0.1.2/go.mod h1:3Lb1OWSmSmcMyjzF6qpAWJvv/yKQmooaeKF+0I0IZNw=
 github.com/git-pkgs/packageurl-go v0.3.1 h1:WM3RBABQZLaRBxgKyYughc3cVBE8KyQxbSC6Jt5ak7M=
 github.com/git-pkgs/packageurl-go v0.3.1/go.mod h1:rcIxiG37BlQLB6FZfgdj9Fm7yjhRQd3l+5o7J0QPAk4=
 github.com/git-pkgs/pom v0.1.4 h1:C6st+XSbF75eKuwfdkDZZtYHoTcaWRIEQYar5VtszUo=
@@ -483,6 +487,8 @@ github.com/nunnatsa/ginkgolinter v0.23.0 h1:x3o4DGYOWbBMP/VdNQKgSj+25aJKx2Pe6lHr
 github.com/nunnatsa/ginkgolinter v0.23.0/go.mod h1:9qN1+0akwXEccwV1CAcCDfcoBlWXHB+ML9884pL4SZ4=
 github.com/oapi-codegen/runtime v1.1.2 h1:P2+CubHq8fO4Q6fV1tqDBZHCwpVpvPg7oKiYzQgXIyI=
 github.com/oapi-codegen/runtime v1.1.2/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
+github.com/odvcencio/gotreesitter v0.15.3 h1:bcSIEMyRrDaFIZw2zwM8cNR03VX6y8CbXFxVzfFSGX0=
+github.com/odvcencio/gotreesitter v0.15.3/go.mod h1:ccYZsDUmAJQAtliLsNHT33F3X4AN7f/Z6JGiPNZoEzY=
 github.com/onsi/ginkgo/v2 v2.28.1 h1:S4hj+HbZp40fNKuLUQOYLDgZLwNUVn19N3Atb98NCyI=
 github.com/onsi/ginkgo/v2 v2.28.1/go.mod h1:CLtbVInNckU3/+gC8LzkGUb9oF+e8W8TdUsxPwvdOgE=
 github.com/onsi/gomega v1.39.1 h1:1IJLAad4zjPn2PsnhH70V4DKRFlrCzGBNrNaru+Vf28=


### PR DESCRIPTION
Adds `brief outline`, which produces a token-friendly summary of a codebase for handing to an LLM: a directory tree plus each file's content with function and method bodies stripped, leaving signatures, types, comments and imports. Output is markdown by default or `-xml`.

The heavy lifting lives in `github.com/git-pkgs/outline` v0.1.0 (pure Go, no CGo, 35 languages). This subcommand wires it to `remote.Resolve` so local paths, git URLs and registry shorthands all work, and exposes `-full`, `-ignore`, `-max-file-size` and `-max-files`.