### PR TITLE
Sanitize CI matrix values and resource filenames in report output

### DIFF
--- a/report/markdown.go
+++ b/report/markdown.go
@@ -233,13 +233,13 @@ func mdPlatforms(w io.Writer, platforms *brief.PlatformInfo) {
 	}
 	_, _ = fmt.Fprintln(w)
 	for _, name := range sortedKeys(platforms.CIMatrixVersions) {
-		_, _ = fmt.Fprintf(w, "**Platforms:** %s %s (CI matrix)\n", name, strings.Join(platforms.CIMatrixVersions[name], ", "))
+		_, _ = fmt.Fprintf(w, "**Platforms:** %s %s (CI matrix)\n", name, sanitize(strings.Join(platforms.CIMatrixVersions[name], ", ")))
 	}
 	for _, file := range sortedKeys(platforms.RuntimeVersionFiles) {
 		_, _ = fmt.Fprintf(w, "- %s: %s\n", sanitize(file), sanitize(platforms.RuntimeVersionFiles[file]))
 	}
 	if len(platforms.CIMatrixOS) > 0 {
-		_, _ = fmt.Fprintf(w, "- OS: %s (CI matrix)\n", strings.Join(platforms.CIMatrixOS, ", "))
+		_, _ = fmt.Fprintf(w, "- OS: %s (CI matrix)\n", sanitize(strings.Join(platforms.CIMatrixOS, ", ")))
 	}
 }
 
@@ -268,7 +268,7 @@ func mdResources(w io.Writer, res *brief.ResourceInfo) {
 
 func mdResource(w io.Writer, path string) {
 	if path != "" {
-		_, _ = fmt.Fprintf(w, "- %s\n", path)
+		_, _ = fmt.Fprintf(w, "- %s\n", sanitize(path))
 	}
 }
 
@@ -278,7 +278,7 @@ func mdResourceGroup(w io.Writer, label string, group map[string]string) {
 	}
 	_, _ = fmt.Fprintf(w, "- %s:\n", label)
 	for _, k := range sortedKeys(group) {
-		_, _ = fmt.Fprintf(w, "  - %s\n", group[k])
+		_, _ = fmt.Fprintf(w, "  - %s\n", sanitize(group[k]))
 	}
 }
 

--- a/report/markdown_test.go
+++ b/report/markdown_test.go
@@ -171,6 +171,52 @@ func TestMarkdownResources(t *testing.T) {
 	}
 }
 
+func TestMarkdownSanitizesCIMatrix(t *testing.T) {
+	r := &brief.Report{
+		Version: "dev",
+		Path:    "/tmp/test",
+		Platforms: &brief.PlatformInfo{
+			CIMatrixVersions: map[string][]string{
+				"node": {"\x1b[31mRED\x1b[0m"},
+			},
+			CIMatrixOS:          []string{"\x1b]0;PWNED\x07-ubuntu"},
+			RuntimeVersionFiles: map[string]string{},
+		},
+	}
+
+	var buf bytes.Buffer
+	Markdown(&buf, r, false)
+	out := buf.String()
+
+	if strings.Contains(out, "\x1b") {
+		t.Errorf("output contains ESC byte\ngot:\n%q", out)
+	}
+	if strings.Contains(out, "\x07") {
+		t.Errorf("output contains BEL byte\ngot:\n%q", out)
+	}
+}
+
+func TestMarkdownSanitizesResources(t *testing.T) {
+	r := &brief.Report{
+		Version: "dev",
+		Path:    "/tmp/test",
+		Resources: &brief.ResourceInfo{
+			Readme: "README\x1b[31mRED\x1b[0m.md",
+			Community: map[string]string{
+				"contributing": "CONTRIBUTING\x1b[31m.md",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	Markdown(&buf, r, false)
+	out := buf.String()
+
+	if strings.Contains(out, "\x1b") {
+		t.Errorf("output contains ESC byte\ngot:\n%q", out)
+	}
+}
+
 func TestMarkdownGit(t *testing.T) {
 	r := &brief.Report{
 		Version: "dev",

--- a/report/report.go
+++ b/report/report.go
@@ -268,13 +268,13 @@ func printPlatforms(w io.Writer, platforms *brief.PlatformInfo) {
 	}
 	_, _ = fmt.Fprintln(w)
 	for _, name := range sortedKeys(platforms.CIMatrixVersions) {
-		_, _ = fmt.Fprintf(w, "Platforms:   %s %s (CI matrix)\n", name, strings.Join(platforms.CIMatrixVersions[name], ", "))
+		_, _ = fmt.Fprintf(w, "Platforms:   %s %s (CI matrix)\n", name, sanitize(strings.Join(platforms.CIMatrixVersions[name], ", ")))
 	}
 	for _, file := range sortedKeys(platforms.RuntimeVersionFiles) {
 		_, _ = fmt.Fprintf(w, "             %s: %s\n", sanitize(file), sanitize(platforms.RuntimeVersionFiles[file]))
 	}
 	if len(platforms.CIMatrixOS) > 0 {
-		_, _ = fmt.Fprintf(w, "             OS: %s (CI matrix)\n", strings.Join(platforms.CIMatrixOS, ", "))
+		_, _ = fmt.Fprintf(w, "             OS: %s (CI matrix)\n", sanitize(strings.Join(platforms.CIMatrixOS, ", ")))
 	}
 }
 
@@ -302,7 +302,7 @@ func printResources(w io.Writer, res *brief.ResourceInfo) {
 
 func printResourceGroup(w io.Writer, label string, group map[string]string) {
 	for _, k := range sortedKeys(group) {
-		_, _ = fmt.Fprintf(w, "%-12s %s\n", label+":", group[k])
+		_, _ = fmt.Fprintf(w, "%-12s %s\n", label+":", sanitize(group[k]))
 	}
 }
 
@@ -467,7 +467,7 @@ func MissingHuman(w io.Writer, r *brief.MissingReport) {
 
 func printResource(w io.Writer, value string) {
 	if value != "" {
-		_, _ = fmt.Fprintf(w, "Resources:   %s\n", value)
+		_, _ = fmt.Fprintf(w, "Resources:   %s\n", sanitize(value))
 	}
 }
 

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -199,6 +199,58 @@ func TestJoinDirs(t *testing.T) {
 	}
 }
 
+func TestHumanSanitizesCIMatrix(t *testing.T) {
+	r := &brief.Report{
+		Version: "dev",
+		Path:    "/tmp/test",
+		Platforms: &brief.PlatformInfo{
+			CIMatrixVersions: map[string][]string{
+				"node": {"\x1b[31mRED\x1b[0m"},
+			},
+			CIMatrixOS:          []string{"\x1b]0;PWNED\x07-ubuntu"},
+			RuntimeVersionFiles: map[string]string{},
+		},
+	}
+
+	var buf bytes.Buffer
+	Human(&buf, r, false)
+	out := buf.String()
+
+	if strings.Contains(out, "\x1b") {
+		t.Errorf("output contains ESC byte\ngot:\n%q", out)
+	}
+	if strings.Contains(out, "\x07") {
+		t.Errorf("output contains BEL byte\ngot:\n%q", out)
+	}
+	if !strings.Contains(out, "[31mRED[0m") {
+		t.Errorf("expected sanitized version string\ngot:\n%s", out)
+	}
+}
+
+func TestHumanSanitizesResources(t *testing.T) {
+	r := &brief.Report{
+		Version: "dev",
+		Path:    "/tmp/test",
+		Resources: &brief.ResourceInfo{
+			Readme: "README\x1b[31mRED\x1b[0m.md",
+			Community: map[string]string{
+				"contributing": "CONTRIBUTING\x1b[31m.md",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	Human(&buf, r, false)
+	out := buf.String()
+
+	if strings.Contains(out, "\x1b") {
+		t.Errorf("output contains ESC byte\ngot:\n%q", out)
+	}
+	if !strings.Contains(out, "README[31mRED[0m.md") {
+		t.Errorf("expected sanitized resource path\ngot:\n%s", out)
+	}
+}
+
 func sampleThreatReport() *brief.ThreatReport {
 	return &brief.ThreatReport{
 		Ecosystems: []string{"ruby"},


### PR DESCRIPTION
`printPlatforms`/`mdPlatforms` printed `CIMatrixVersions` and `CIMatrixOS` without `sanitize()`, and `printResource`/`printResourceGroup` (plus their markdown equivalents) did the same for resource paths. A repo with control characters in workflow matrix values or filenames could write raw ANSI/OSC sequences to the operator's terminal.

Wraps all eight call sites with the existing `sanitize()` function. JSON output was already safe since `encoding/json` escapes control bytes.