### PR TITLE
Reject directories when matching file globs

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -414,11 +414,17 @@ func (e *Engine) matchTool(tool *kb.ToolDef) brief.Confidence {
 }
 
 // exists checks if a file, directory, or glob pattern matches something at the project root.
+// A trailing "/" means the pattern must match a directory. Glob patterns without
+// a trailing "/" only match regular files so that a NEWS.d/ directory does not
+// register as D source.
 func (e *Engine) exists(pattern string) bool {
 	e.filesChecked++
 
-	if strings.HasSuffix(pattern, "/") {
-		info, err := os.Stat(filepath.Join(e.Root, pattern))
+	if dir, ok := strings.CutSuffix(pattern, "/"); ok {
+		if kb.HasGlobPattern(dir) {
+			return e.globMatches(dir, true)
+		}
+		info, err := os.Stat(filepath.Join(e.Root, dir))
 		return err == nil && info.IsDir()
 	}
 
@@ -428,12 +434,27 @@ func (e *Engine) exists(pattern string) bool {
 	}
 
 	if kb.HasGlobPattern(pattern) {
-		matches, err := filepath.Glob(filepath.Join(e.Root, pattern))
-		return err == nil && len(matches) > 0
+		return e.globMatches(pattern, false)
 	}
 
 	_, err := os.Stat(filepath.Join(e.Root, pattern))
 	return err == nil
+}
+
+// globMatches reports whether a root-level glob pattern matches at least one
+// entry of the requested kind.
+func (e *Engine) globMatches(pattern string, wantDir bool) bool {
+	matches, err := filepath.Glob(filepath.Join(e.Root, pattern))
+	if err != nil {
+		return false
+	}
+	for _, m := range matches {
+		info, err := os.Stat(m)
+		if err == nil && info.IsDir() == wantDir {
+			return true
+		}
+	}
+	return false
 }
 
 // recursiveGlob handles ** patterns by checking against the cached file extension set.

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -773,6 +773,46 @@ func TestInvokeDetection(t *testing.T) {
 	}
 }
 
+func TestGlobIgnoresDirectories(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, d := range []string{"NEWS.d", "scratch.js"} {
+		if err := os.Mkdir(filepath.Join(dir, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	r, err := New(loadKB(t), dir).Run()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, lang := range r.Languages {
+		if lang.Name == "D" || lang.Name == "JavaScript" {
+			t.Errorf("directory with source extension should not trigger %s detection", lang.Name)
+		}
+	}
+	if len(r.Languages) == 0 || r.Languages[0].Name != "Go" {
+		t.Errorf("expected Go as primary language, got %v", r.Languages)
+	}
+}
+
+func TestDirectoryGlobPattern(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "Foo.xcodeproj"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	engine := New(loadKB(t), dir)
+	if !engine.exists("*.xcodeproj/") {
+		t.Error("expected *.xcodeproj/ to match Foo.xcodeproj directory")
+	}
+	if engine.exists("*.xcodeproj") {
+		t.Error("*.xcodeproj without trailing slash should not match a directory")
+	}
+}
+
 func assertToolDetected(t *testing.T, r *brief.Report, category, name string) {
 	t.Helper()
 	tools, ok := r.Tools[category]

--- a/knowledge/objc/language.toml
+++ b/knowledge/objc/language.toml
@@ -6,7 +6,7 @@ docs = "https://developer.apple.com/library/archive/documentation/Cocoa/Conceptu
 description = "Object-oriented superset of C for Apple platforms"
 
 [detect]
-files = ["*.m", "**/*.m", "*.mm", "**/*.mm", "*.xcodeproj", "*.xcworkspace"]
+files = ["*.m", "**/*.m", "*.mm", "**/*.mm", "*.xcodeproj/", "*.xcworkspace/"]
 ecosystems = ["objc"]
 
 [taxonomy]


### PR DESCRIPTION
Closes #58.

`filepath.Glob` returns directories as well as files, so a `NEWS.d/` directory matched the `*.d` pattern and reported D as a project language. Same for any `foo.js/` style directory.

`exists()` now stats glob results and only accepts regular files unless the pattern ends with `/`, in which case it only accepts directories. The trailing-slash branch now handles glob patterns too, so `*.xcodeproj/` works (it previously tried to stat a literal `*`). The Objective-C entry is updated to use `*.xcodeproj/` and `*.xcworkspace/` since those are bundle directories, not files.

Before:

```
$ mkdir NEWS.d scratch.js
$ brief -human . | head -3
Language:        Go (also: D, JavaScript)
```

After:

```
Language:        Go
```

This will conflict trivially with #70 in the glob branch of `exists()`; whichever lands second just needs to thread `isTracked` through `globMatches`.