### PR TITLE
Split runtime libraries into their own category

### DIFF
--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -356,8 +356,8 @@ func TestPythonProject(t *testing.T) {
 	assertToolDetected(t, r, "typecheck", "mypy")
 
 	// Detection-only library defs via dependencies primitive
-	assertToolDetected(t, r, "build", "requests")
-	assertToolDetected(t, r, "build", "Jinja2")
+	assertToolDetected(t, r, "library", "requests")
+	assertToolDetected(t, r, "library", "Jinja2")
 
 	// Layout
 	if r.Layout == nil {

--- a/knowledge/csharp/newtonsoft-json.toml
+++ b/knowledge/csharp/newtonsoft-json.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "Newtonsoft.Json"
-category = "build"
+category = "library"
 homepage = "https://www.newtonsoft.com/json"
 docs = "https://www.newtonsoft.com/json"
 repo = "https://github.com/JamesNK/Newtonsoft.Json"

--- a/knowledge/go/chi.toml
+++ b/knowledge/go/chi.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "Chi"
-category = "build"
+category = "library"
 homepage = "https://go-chi.io"
 docs = "https://go-chi.io/#/README"
 repo = "https://github.com/go-chi/chi"

--- a/knowledge/go/golang-jwt.toml
+++ b/knowledge/go/golang-jwt.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "golang-jwt"
-category = "build"
+category = "library"
 homepage = "https://golang-jwt.github.io/jwt"
 docs = "https://golang-jwt.github.io/jwt"
 repo = "https://github.com/golang-jwt/jwt"

--- a/knowledge/go/resty.toml
+++ b/knowledge/go/resty.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "Resty"
-category = "build"
+category = "library"
 homepage = "https://resty.dev"
 docs = "https://resty.dev"
 repo = "https://github.com/go-resty/resty"

--- a/knowledge/java/freemarker.toml
+++ b/knowledge/java/freemarker.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "FreeMarker"
-category = "build"
+category = "library"
 homepage = "https://freemarker.apache.org"
 docs = "https://freemarker.apache.org"
 repo = "https://github.com/apache/freemarker"

--- a/knowledge/java/gson.toml
+++ b/knowledge/java/gson.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "Gson"
-category = "build"
+category = "library"
 homepage = "https://github.com/google/gson"
 docs = "https://github.com/google/gson"
 repo = "https://github.com/google/gson"

--- a/knowledge/java/jackson.toml
+++ b/knowledge/java/jackson.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "Jackson"
-category = "build"
+category = "library"
 homepage = "https://github.com/FasterXML/jackson"
 docs = "https://github.com/FasterXML/jackson"
 repo = "https://github.com/FasterXML/jackson-databind"

--- a/knowledge/java/okhttp.toml
+++ b/knowledge/java/okhttp.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "OkHttp"
-category = "build"
+category = "library"
 homepage = "https://square.github.io/okhttp"
 docs = "https://square.github.io/okhttp"
 repo = "https://github.com/square/okhttp"

--- a/knowledge/java/snakeyaml.toml
+++ b/knowledge/java/snakeyaml.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "SnakeYAML"
-category = "build"
+category = "library"
 homepage = "https://bitbucket.org/snakeyaml/snakeyaml"
 docs = "https://bitbucket.org/snakeyaml/snakeyaml"
 repo = "https://bitbucket.org/snakeyaml/snakeyaml"

--- a/knowledge/java/thymeleaf.toml
+++ b/knowledge/java/thymeleaf.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "Thymeleaf"
-category = "build"
+category = "library"
 homepage = "https://www.thymeleaf.org"
 docs = "https://www.thymeleaf.org"
 repo = "https://github.com/thymeleaf/thymeleaf"

--- a/knowledge/java/xstream.toml
+++ b/knowledge/java/xstream.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "XStream"
-category = "build"
+category = "library"
 homepage = "https://x-stream.github.io"
 docs = "https://x-stream.github.io"
 repo = "https://github.com/x-stream/xstream"

--- a/knowledge/node/axios.toml
+++ b/knowledge/node/axios.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "axios"
-category = "build"
+category = "library"
 homepage = "https://axios-http.com"
 docs = "https://axios-http.com"
 repo = "https://github.com/axios/axios"

--- a/knowledge/node/bcrypt-js.toml
+++ b/knowledge/node/bcrypt-js.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "bcrypt"
-category = "build"
+category = "library"
 homepage = "https://github.com/kelektiv/node.bcrypt.js"
 docs = "https://github.com/kelektiv/node.bcrypt.js"
 repo = "https://github.com/kelektiv/node.bcrypt.js"

--- a/knowledge/node/crypto-js.toml
+++ b/knowledge/node/crypto-js.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "crypto-js"
-category = "build"
+category = "library"
 homepage = "https://github.com/brix/crypto-js"
 docs = "https://github.com/brix/crypto-js"
 repo = "https://github.com/brix/crypto-js"

--- a/knowledge/node/ejs.toml
+++ b/knowledge/node/ejs.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "EJS"
-category = "build"
+category = "library"
 homepage = "https://ejs.co"
 docs = "https://ejs.co"
 repo = "https://github.com/mde/ejs"

--- a/knowledge/node/execa.toml
+++ b/knowledge/node/execa.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "execa"
-category = "build"
+category = "library"
 homepage = "https://github.com/sindresorhus/execa"
 docs = "https://github.com/sindresorhus/execa"
 repo = "https://github.com/sindresorhus/execa"

--- a/knowledge/node/fast-xml-parser.toml
+++ b/knowledge/node/fast-xml-parser.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "fast-xml-parser"
-category = "build"
+category = "library"
 homepage = "https://github.com/NaturalIntelligence/fast-xml-parser"
 docs = "https://github.com/NaturalIntelligence/fast-xml-parser"
 repo = "https://github.com/NaturalIntelligence/fast-xml-parser"

--- a/knowledge/node/formidable.toml
+++ b/knowledge/node/formidable.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "Formidable"
-category = "build"
+category = "library"
 homepage = "https://github.com/node-formidable/formidable"
 docs = "https://github.com/node-formidable/formidable"
 repo = "https://github.com/node-formidable/formidable"

--- a/knowledge/node/got.toml
+++ b/knowledge/node/got.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "got"
-category = "build"
+category = "library"
 homepage = "https://github.com/sindresorhus/got"
 docs = "https://github.com/sindresorhus/got"
 repo = "https://github.com/sindresorhus/got"

--- a/knowledge/node/handlebars.toml
+++ b/knowledge/node/handlebars.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "Handlebars"
-category = "build"
+category = "library"
 homepage = "https://handlebarsjs.com"
 docs = "https://handlebarsjs.com"
 repo = "https://github.com/handlebars-lang/handlebars.js"

--- a/knowledge/node/js-yaml.toml
+++ b/knowledge/node/js-yaml.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "js-yaml"
-category = "build"
+category = "library"
 homepage = "https://github.com/nodeca/js-yaml"
 docs = "https://github.com/nodeca/js-yaml"
 repo = "https://github.com/nodeca/js-yaml"

--- a/knowledge/node/jsonwebtoken.toml
+++ b/knowledge/node/jsonwebtoken.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "jsonwebtoken"
-category = "build"
+category = "library"
 homepage = "https://github.com/auth0/node-jsonwebtoken"
 docs = "https://github.com/auth0/node-jsonwebtoken"
 repo = "https://github.com/auth0/node-jsonwebtoken"

--- a/knowledge/node/ldapjs.toml
+++ b/knowledge/node/ldapjs.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "ldapjs"
-category = "build"
+category = "library"
 homepage = "http://ldapjs.org"
 docs = "http://ldapjs.org"
 repo = "https://github.com/ldapjs/node-ldapjs"

--- a/knowledge/node/multer.toml
+++ b/knowledge/node/multer.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "Multer"
-category = "build"
+category = "library"
 homepage = "https://github.com/expressjs/multer"
 docs = "https://github.com/expressjs/multer"
 repo = "https://github.com/expressjs/multer"

--- a/knowledge/node/mustache-js.toml
+++ b/knowledge/node/mustache-js.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "Mustache"
-category = "build"
+category = "library"
 homepage = "https://github.com/janl/mustache.js"
 docs = "https://github.com/janl/mustache.js"
 repo = "https://github.com/janl/mustache.js"

--- a/knowledge/node/next-auth.toml
+++ b/knowledge/node/next-auth.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "NextAuth.js"
-category = "build"
+category = "library"
 homepage = "https://next-auth.js.org"
 docs = "https://next-auth.js.org"
 repo = "https://github.com/nextauthjs/next-auth"

--- a/knowledge/node/node-fetch.toml
+++ b/knowledge/node/node-fetch.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "node-fetch"
-category = "build"
+category = "library"
 homepage = "https://github.com/node-fetch/node-fetch"
 docs = "https://github.com/node-fetch/node-fetch"
 repo = "https://github.com/node-fetch/node-fetch"

--- a/knowledge/node/nunjucks.toml
+++ b/knowledge/node/nunjucks.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "Nunjucks"
-category = "build"
+category = "library"
 homepage = "https://mozilla.github.io/nunjucks"
 docs = "https://mozilla.github.io/nunjucks"
 repo = "https://github.com/mozilla/nunjucks"

--- a/knowledge/node/passport.toml
+++ b/knowledge/node/passport.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "Passport"
-category = "build"
+category = "library"
 homepage = "https://www.passportjs.org"
 docs = "https://www.passportjs.org"
 repo = "https://github.com/jaredhanson/passport"

--- a/knowledge/node/pug.toml
+++ b/knowledge/node/pug.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "Pug"
-category = "build"
+category = "library"
 homepage = "https://pugjs.org"
 docs = "https://pugjs.org"
 repo = "https://github.com/pugjs/pug"

--- a/knowledge/node/react.toml
+++ b/knowledge/node/react.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "React"
-category = "build"
+category = "library"
 homepage = "https://react.dev"
 docs = "https://react.dev/learn"
 repo = "https://github.com/facebook/react"

--- a/knowledge/node/shelljs.toml
+++ b/knowledge/node/shelljs.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "ShellJS"
-category = "build"
+category = "library"
 homepage = "https://github.com/shelljs/shelljs"
 docs = "https://github.com/shelljs/shelljs"
 repo = "https://github.com/shelljs/shelljs"

--- a/knowledge/node/solidjs.toml
+++ b/knowledge/node/solidjs.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "SolidJS"
-category = "build"
+category = "library"
 homepage = "https://www.solidjs.com"
 docs = "https://docs.solidjs.com"
 repo = "https://github.com/solidjs/solid"

--- a/knowledge/node/tailwind.toml
+++ b/knowledge/node/tailwind.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "Tailwind CSS"
-category = "build"
+category = "library"
 homepage = "https://tailwindcss.com"
 docs = "https://tailwindcss.com/docs"
 repo = "https://github.com/tailwindlabs/tailwindcss"

--- a/knowledge/node/undici.toml
+++ b/knowledge/node/undici.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "undici"
-category = "build"
+category = "library"
 homepage = "https://undici.nodejs.org"
 docs = "https://undici.nodejs.org"
 repo = "https://github.com/nodejs/undici"

--- a/knowledge/node/unocss.toml
+++ b/knowledge/node/unocss.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "UnoCSS"
-category = "build"
+category = "library"
 homepage = "https://unocss.dev"
 docs = "https://unocss.dev/guide/"
 repo = "https://github.com/unocss/unocss"

--- a/knowledge/node/xml2js.toml
+++ b/knowledge/node/xml2js.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "xml2js"
-category = "build"
+category = "library"
 homepage = "https://github.com/Leonidas-from-XIV/node-xml2js"
 docs = "https://github.com/Leonidas-from-XIV/node-xml2js"
 repo = "https://github.com/Leonidas-from-XIV/node-xml2js"

--- a/knowledge/php/guzzle.toml
+++ b/knowledge/php/guzzle.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "Guzzle"
-category = "build"
+category = "library"
 homepage = "https://docs.guzzlephp.org"
 docs = "https://docs.guzzlephp.org"
 repo = "https://github.com/guzzle/guzzle"

--- a/knowledge/php/ldap.toml
+++ b/knowledge/php/ldap.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "PHP LDAP"
-category = "build"
+category = "library"
 homepage = "https://www.php.net/manual/en/book.ldap.php"
 docs = "https://www.php.net/manual/en/book.ldap.php"
 description = "LDAP extension for PHP"

--- a/knowledge/php/twig.toml
+++ b/knowledge/php/twig.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "Twig"
-category = "build"
+category = "library"
 homepage = "https://twig.symfony.com"
 docs = "https://twig.symfony.com"
 repo = "https://github.com/twigphp/Twig"

--- a/knowledge/python/aiohttp.toml
+++ b/knowledge/python/aiohttp.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "aiohttp"
-category = "build"
+category = "library"
 homepage = "https://docs.aiohttp.org"
 docs = "https://docs.aiohttp.org"
 repo = "https://github.com/aio-libs/aiohttp"

--- a/knowledge/python/authlib.toml
+++ b/knowledge/python/authlib.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "Authlib"
-category = "build"
+category = "library"
 homepage = "https://authlib.org"
 docs = "https://authlib.org"
 repo = "https://github.com/lepture/authlib"

--- a/knowledge/python/cryptography.toml
+++ b/knowledge/python/cryptography.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "cryptography"
-category = "build"
+category = "library"
 homepage = "https://cryptography.io"
 docs = "https://cryptography.io"
 repo = "https://github.com/pyca/cryptography"

--- a/knowledge/python/defusedxml.toml
+++ b/knowledge/python/defusedxml.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "defusedxml"
-category = "build"
+category = "library"
 homepage = "https://github.com/tiran/defusedxml"
 docs = "https://github.com/tiran/defusedxml"
 repo = "https://github.com/tiran/defusedxml"

--- a/knowledge/python/httpx.toml
+++ b/knowledge/python/httpx.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "httpx"
-category = "build"
+category = "library"
 homepage = "https://www.python-httpx.org"
 docs = "https://www.python-httpx.org"
 repo = "https://github.com/encode/httpx"

--- a/knowledge/python/invoke.toml
+++ b/knowledge/python/invoke.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "Invoke"
-category = "build"
+category = "library"
 homepage = "https://www.pyinvoke.org"
 docs = "https://www.pyinvoke.org"
 repo = "https://github.com/pyinvoke/invoke"

--- a/knowledge/python/jinja2.toml
+++ b/knowledge/python/jinja2.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "Jinja2"
-category = "build"
+category = "library"
 homepage = "https://jinja.palletsprojects.com"
 docs = "https://jinja.palletsprojects.com"
 repo = "https://github.com/pallets/jinja"

--- a/knowledge/python/ldap3.toml
+++ b/knowledge/python/ldap3.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "ldap3"
-category = "build"
+category = "library"
 homepage = "https://ldap3.readthedocs.io"
 docs = "https://ldap3.readthedocs.io"
 repo = "https://github.com/cannatag/ldap3"

--- a/knowledge/python/lxml.toml
+++ b/knowledge/python/lxml.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "lxml"
-category = "build"
+category = "library"
 homepage = "https://lxml.de"
 docs = "https://lxml.de"
 repo = "https://github.com/lxml/lxml"

--- a/knowledge/python/mako.toml
+++ b/knowledge/python/mako.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "Mako"
-category = "build"
+category = "library"
 homepage = "https://www.makotemplates.org"
 docs = "https://www.makotemplates.org"
 repo = "https://github.com/sqlalchemy/mako"

--- a/knowledge/python/pycryptodome.toml
+++ b/knowledge/python/pycryptodome.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "PyCryptodome"
-category = "build"
+category = "library"
 homepage = "https://www.pycryptodome.org"
 docs = "https://www.pycryptodome.org"
 repo = "https://github.com/Legrandin/pycryptodome"

--- a/knowledge/python/pyjwt.toml
+++ b/knowledge/python/pyjwt.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "PyJWT"
-category = "build"
+category = "library"
 homepage = "https://pyjwt.readthedocs.io"
 docs = "https://pyjwt.readthedocs.io"
 repo = "https://github.com/jpadilla/pyjwt"

--- a/knowledge/python/python-jose.toml
+++ b/knowledge/python/python-jose.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "python-jose"
-category = "build"
+category = "library"
 homepage = "https://github.com/mpdavis/python-jose"
 docs = "https://github.com/mpdavis/python-jose"
 repo = "https://github.com/mpdavis/python-jose"

--- a/knowledge/python/python-multipart.toml
+++ b/knowledge/python/python-multipart.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "python-multipart"
-category = "build"
+category = "library"
 homepage = "https://github.com/Kludex/python-multipart"
 docs = "https://github.com/Kludex/python-multipart"
 repo = "https://github.com/Kludex/python-multipart"

--- a/knowledge/python/pyyaml.toml
+++ b/knowledge/python/pyyaml.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "PyYAML"
-category = "build"
+category = "library"
 homepage = "https://pyyaml.org"
 docs = "https://pyyaml.org"
 repo = "https://github.com/yaml/pyyaml"

--- a/knowledge/python/requests.toml
+++ b/knowledge/python/requests.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "requests"
-category = "build"
+category = "library"
 homepage = "https://requests.readthedocs.io"
 docs = "https://requests.readthedocs.io"
 repo = "https://github.com/psf/requests"

--- a/knowledge/python/ruamel-yaml.toml
+++ b/knowledge/python/ruamel-yaml.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "ruamel.yaml"
-category = "build"
+category = "library"
 homepage = "https://yaml.readthedocs.io"
 docs = "https://yaml.readthedocs.io"
 repo = "https://sourceforge.net/projects/ruamel-yaml"

--- a/knowledge/python/sh-py.toml
+++ b/knowledge/python/sh-py.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "sh"
-category = "build"
+category = "library"
 homepage = "https://sh.readthedocs.io"
 docs = "https://sh.readthedocs.io"
 repo = "https://github.com/amoffat/sh"

--- a/knowledge/python/urllib3.toml
+++ b/knowledge/python/urllib3.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "urllib3"
-category = "build"
+category = "library"
 homepage = "https://urllib3.readthedocs.io"
 docs = "https://urllib3.readthedocs.io"
 repo = "https://github.com/urllib3/urllib3"

--- a/knowledge/ruby/bcrypt-rb.toml
+++ b/knowledge/ruby/bcrypt-rb.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "bcrypt-ruby"
-category = "build"
+category = "library"
 homepage = "https://github.com/bcrypt-ruby/bcrypt-ruby"
 docs = "https://github.com/bcrypt-ruby/bcrypt-ruby"
 repo = "https://github.com/bcrypt-ruby/bcrypt-ruby"

--- a/knowledge/ruby/carrierwave.toml
+++ b/knowledge/ruby/carrierwave.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "CarrierWave"
-category = "build"
+category = "library"
 homepage = "https://github.com/carrierwaveuploader/carrierwave"
 docs = "https://github.com/carrierwaveuploader/carrierwave"
 repo = "https://github.com/carrierwaveuploader/carrierwave"

--- a/knowledge/ruby/devise.toml
+++ b/knowledge/ruby/devise.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "Devise"
-category = "build"
+category = "library"
 homepage = "https://github.com/heartcombo/devise"
 docs = "https://github.com/heartcombo/devise"
 repo = "https://github.com/heartcombo/devise"

--- a/knowledge/ruby/faraday.toml
+++ b/knowledge/ruby/faraday.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "Faraday"
-category = "build"
+category = "library"
 homepage = "https://lostisland.github.io/faraday"
 docs = "https://lostisland.github.io/faraday"
 repo = "https://github.com/lostisland/faraday"

--- a/knowledge/ruby/haml.toml
+++ b/knowledge/ruby/haml.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "Haml"
-category = "build"
+category = "library"
 homepage = "https://haml.info"
 docs = "https://haml.info"
 repo = "https://github.com/haml/haml"

--- a/knowledge/ruby/httparty.toml
+++ b/knowledge/ruby/httparty.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "HTTParty"
-category = "build"
+category = "library"
 homepage = "https://github.com/jnunemaker/httparty"
 docs = "https://github.com/jnunemaker/httparty"
 repo = "https://github.com/jnunemaker/httparty"

--- a/knowledge/ruby/jwt-rb.toml
+++ b/knowledge/ruby/jwt-rb.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "ruby-jwt"
-category = "build"
+category = "library"
 homepage = "https://github.com/jwt/ruby-jwt"
 docs = "https://github.com/jwt/ruby-jwt"
 repo = "https://github.com/jwt/ruby-jwt"

--- a/knowledge/ruby/liquid.toml
+++ b/knowledge/ruby/liquid.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "Liquid"
-category = "build"
+category = "library"
 homepage = "https://shopify.github.io/liquid"
 docs = "https://shopify.github.io/liquid"
 repo = "https://github.com/Shopify/liquid"

--- a/knowledge/ruby/net-ldap.toml
+++ b/knowledge/ruby/net-ldap.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "net-ldap"
-category = "build"
+category = "library"
 homepage = "https://github.com/ruby-ldap/ruby-net-ldap"
 docs = "https://www.rubydoc.info/gems/net-ldap"
 repo = "https://github.com/ruby-ldap/ruby-net-ldap"

--- a/knowledge/ruby/nokogiri.toml
+++ b/knowledge/ruby/nokogiri.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "Nokogiri"
-category = "build"
+category = "library"
 homepage = "https://nokogiri.org"
 docs = "https://nokogiri.org"
 repo = "https://github.com/sparklemotion/nokogiri"

--- a/knowledge/ruby/omniauth.toml
+++ b/knowledge/ruby/omniauth.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "OmniAuth"
-category = "build"
+category = "library"
 homepage = "https://github.com/omniauth/omniauth"
 docs = "https://github.com/omniauth/omniauth"
 repo = "https://github.com/omniauth/omniauth"

--- a/knowledge/ruby/ox.toml
+++ b/knowledge/ruby/ox.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "Ox"
-category = "build"
+category = "library"
 homepage = "https://github.com/ohler55/ox"
 docs = "https://github.com/ohler55/ox"
 repo = "https://github.com/ohler55/ox"

--- a/knowledge/ruby/rest-client-rb.toml
+++ b/knowledge/ruby/rest-client-rb.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "RestClient"
-category = "build"
+category = "library"
 homepage = "https://github.com/rest-client/rest-client"
 docs = "https://github.com/rest-client/rest-client"
 repo = "https://github.com/rest-client/rest-client"

--- a/knowledge/ruby/shrine.toml
+++ b/knowledge/ruby/shrine.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "Shrine"
-category = "build"
+category = "library"
 homepage = "https://shrinerb.com"
 docs = "https://shrinerb.com"
 repo = "https://github.com/shrinerb/shrine"

--- a/knowledge/ruby/slim.toml
+++ b/knowledge/ruby/slim.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "Slim"
-category = "build"
+category = "library"
 homepage = "https://slim-template.github.io"
 docs = "https://slim-template.github.io"
 repo = "https://github.com/slim-template/slim"

--- a/knowledge/rust/reqwest.toml
+++ b/knowledge/rust/reqwest.toml
@@ -1,6 +1,6 @@
 [tool]
 name = "reqwest"
-category = "build"
+category = "library"
 homepage = "https://docs.rs/reqwest"
 docs = "https://docs.rs/reqwest"
 repo = "https://github.com/seanmonstar/reqwest"

--- a/report/report.go
+++ b/report/report.go
@@ -36,7 +36,7 @@ func JSON(w io.Writer, r *brief.Report) error {
 const maxDisplayItems = 20 // max items to show before truncating
 
 // CategoryOrder defines the stable display order for tool categories.
-var CategoryOrder = []string{"test", "lint", "format", "typecheck", "docs", "build", "codegen", "database", "security", "ci", "container", "infrastructure", "monorepo", "environment", "i18n", "release", "coverage", "dependency_bot"}
+var CategoryOrder = []string{"test", "lint", "format", "typecheck", "docs", "build", "library", "codegen", "database", "security", "ci", "container", "infrastructure", "monorepo", "environment", "i18n", "release", "coverage", "dependency_bot"}
 
 // CategoryLabels maps category keys to human-readable labels.
 var CategoryLabels = map[string]string{
@@ -46,6 +46,7 @@ var CategoryLabels = map[string]string{
 	"typecheck":      "Typecheck",
 	"docs":           "Docs",
 	"build":          "Build",
+	"library":        "Library",
 	"codegen":        "Codegen",
 	"database":       "Database",
 	"security":       "Security",


### PR DESCRIPTION
Closes #59.

75 knowledge base entries for runtime libraries (`requests`, `axios`, `jinja2`, `bcrypt`, `Nokogiri`, `defusedxml`, etc.) were sitting in `category = "build"`, so a Python project that depends on `defusedxml` reported it under `Build:` in the human output. These entries exist mainly to carry security sinks for `brief threat-model` and were never build tooling.

This moves every entry with `category = "build"` and `taxonomy.role = ["library"]` to a new `library` category, displayed right after `Build` in the human and markdown output. The `build` category is now just frameworks and actual build tools (CMake, GoReleaser, esbuild, Django, Rails and so on).

Before:

```
Build:       defusedxml
```

After:

```
Library:     defusedxml
             requests
```

The reporter also asked why a single-file directory shows "472 files checked". That counter is the number of detection-rule file probes attempted, not files on disk; renaming it is a separate change.