### PR TITLE
Detect Invoke as a task runner via tasks.py

### DIFF
--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -733,6 +733,46 @@ func TestTaskRunnerDetection(t *testing.T) {
 	}
 }
 
+func TestInvokeDetection(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "foo.py"), []byte("x = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tasks := "from invoke import task\n\n@task\ndef build(c):\n    c.run('true')\n"
+	if err := os.WriteFile(filepath.Join(dir, "tasks.py"), []byte(tasks), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := New(loadKB(t), dir).Run()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertToolDetected(t, r, "build", "Invoke")
+	for _, d := range r.Tools["build"] {
+		if d.Name == "Invoke" {
+			if d.Command == nil || d.Command.Run != "invoke --list" {
+				t.Errorf("expected 'invoke --list' command, got %v", d.Command)
+			}
+		}
+	}
+
+	// A tasks.py that doesn't import invoke should not trigger detection.
+	celery := "from celery import shared_task\n\n@shared_task\ndef foo():\n    pass\n"
+	if err := os.WriteFile(filepath.Join(dir, "tasks.py"), []byte(celery), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	r, err = New(loadKB(t), dir).Run()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, d := range r.Tools["build"] {
+		if d.Name == "Invoke" {
+			t.Error("tasks.py without invoke import should not trigger Invoke detection")
+		}
+	}
+}
+
 func assertToolDetected(t *testing.T, r *brief.Report, category, name string) {
 	t.Helper()
 	tools, ok := r.Tools[category]

--- a/knowledge/python/invoke.toml
+++ b/knowledge/python/invoke.toml
@@ -1,19 +1,29 @@
 [tool]
 name = "Invoke"
-category = "library"
+category = "build"
 homepage = "https://www.pyinvoke.org"
-docs = "https://www.pyinvoke.org"
+docs = "https://docs.pyinvoke.org"
 repo = "https://github.com/pyinvoke/invoke"
-description = "Task execution and command running"
+description = "Pythonic task execution, like Make or Rake"
 
 [detect]
+files = ["invoke.yaml", "invoke.yml", "invoke.json"]
 dependencies = ["invoke"]
 ecosystems = ["python"]
+[detect.file_contains]
+"tasks.py" = ["from invoke", "import invoke"]
+"tasks/__init__.py" = ["from invoke", "import invoke"]
+
+[commands]
+run = "invoke --list"
+alternatives = ["inv --list"]
+
+[config]
+files = ["tasks.py", "invoke.yaml", "invoke.yml", "invoke.json"]
 
 [taxonomy]
-role = ["library"]
-function = ["process-execution", "automation"]
-layer = ["backend"]
+role = ["build-tool"]
+function = ["automation", "process-execution"]
 
 [[security.sinks]]
 symbol = "Context.run"


### PR DESCRIPTION
Closes #60.

Invoke had a knowledge base entry but it was tagged as a runtime library with no command and no file detection, so it only matched when `invoke` appeared in a manifest and showed up as a bare name with nothing actionable.

This treats it the same as Make, Rake and Mage: `role = ["build-tool"]`, detected via `tasks.py` or `tasks/__init__.py` containing `from invoke` / `import invoke`, or via an `invoke.{yaml,yml,json}` config file, or via the dependency. The content check avoids false positives on Celery and Django projects that also use `tasks.py`. The suggested command is `invoke --list`.

```
Build:       Invoke (invoke --list)  [tasks.py]
```

The reporter's repro listed `pyinvoke` as the dependency name; the PyPI package is `invoke`, which is what the dependency rule already matched.

#72 moved this file to `category = "library"` because of the old `role = ["library"]`. With the role changed to `build-tool` here it should stay in `build`; whichever lands second should keep `category = "build"` for this entry.