### PR TITLE
Add tool entries for Just, Task, Pixi, Spin

### DIFF
--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -548,6 +548,66 @@ func TestDetectSelfNotTriggeredOnOtherGoProjects(t *testing.T) {
 	}
 }
 
+func TestTaskRunnerDetection(t *testing.T) {
+	cases := []struct {
+		name     string
+		files    map[string]string
+		category string
+		command  string
+	}{
+		{
+			name:     "Just",
+			files:    map[string]string{"justfile": "default:\n\techo hi\n"},
+			category: "build",
+			command:  "just --list",
+		},
+		{
+			name:     "Task",
+			files:    map[string]string{"Taskfile.yml": "version: '3'\ntasks:\n  hello:\n    cmds: [echo hi]\n"},
+			category: "build",
+			command:  "task --list-all",
+		},
+		{
+			name:     "Pixi",
+			files:    map[string]string{"pixi.toml": "[project]\nname = \"x\"\n"},
+			category: "environment",
+			command:  "pixi install",
+		},
+		{
+			name: "Spin",
+			files: map[string]string{
+				"x.py":           "x = 1\n",
+				"pyproject.toml": "[project]\nname = \"x\"\n[tool.spin]\npackage = \"x\"\n",
+			},
+			category: "build",
+			command:  "spin",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for name, body := range tc.files {
+				if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			r, err := New(loadKB(t), dir).Run()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			assertToolDetected(t, r, tc.category, tc.name)
+			for _, d := range r.Tools[tc.category] {
+				if d.Name == tc.name {
+					if d.Command == nil || d.Command.Run != tc.command {
+						t.Errorf("expected command %q, got %v", tc.command, d.Command)
+					}
+				}
+			}
+		})
+	}
+}
+
 func assertToolDetected(t *testing.T, r *brief.Report, category, name string) {
 	t.Helper()
 	tools, ok := r.Tools[category]

--- a/knowledge/_shared/just.toml
+++ b/knowledge/_shared/just.toml
@@ -1,0 +1,21 @@
+[tool]
+name = "Just"
+category = "build"
+homepage = "https://just.systems"
+docs = "https://just.systems/man/en/"
+repo = "https://github.com/casey/just"
+description = "Command runner with Make-like syntax"
+
+[detect]
+files = ["justfile", "Justfile", ".justfile", "JUSTFILE"]
+
+[commands]
+run = "just --list"
+alternatives = ["just"]
+
+[config]
+files = ["justfile", "Justfile", ".justfile"]
+
+[taxonomy]
+role = ["build-tool"]
+function = ["automation"]

--- a/knowledge/_shared/pixi.toml
+++ b/knowledge/_shared/pixi.toml
@@ -1,0 +1,24 @@
+[tool]
+name = "Pixi"
+category = "environment"
+homepage = "https://pixi.sh"
+docs = "https://pixi.sh/latest/"
+repo = "https://github.com/prefix-dev/pixi"
+description = "Conda-based package and environment manager with a task runner"
+
+[detect]
+files = ["pixi.toml", "pixi.lock"]
+[detect.key_exists]
+"pyproject.toml" = ["tool.pixi"]
+
+[commands]
+run = "pixi install"
+alternatives = ["pixi task list", "pixi run"]
+
+[config]
+files = ["pixi.toml", "pixi.lock"]
+lockfile = "pixi.lock"
+
+[taxonomy]
+role = ["build-tool"]
+function = ["runtime-management", "automation"]

--- a/knowledge/_shared/task.toml
+++ b/knowledge/_shared/task.toml
@@ -1,0 +1,21 @@
+[tool]
+name = "Task"
+category = "build"
+homepage = "https://taskfile.dev"
+docs = "https://taskfile.dev/usage/"
+repo = "https://github.com/go-task/task"
+description = "Task runner and build tool configured via YAML"
+
+[detect]
+files = ["Taskfile.yml", "Taskfile.yaml", "Taskfile.dist.yml", "Taskfile.dist.yaml"]
+
+[commands]
+run = "task --list-all"
+alternatives = ["task"]
+
+[config]
+files = ["Taskfile.yml", "Taskfile.yaml", "Taskfile.dist.yml", "Taskfile.dist.yaml"]
+
+[taxonomy]
+role = ["build-tool"]
+function = ["automation"]

--- a/knowledge/python/spin.toml
+++ b/knowledge/python/spin.toml
@@ -1,0 +1,26 @@
+[tool]
+name = "Spin"
+category = "build"
+homepage = "https://github.com/scientific-python/spin"
+docs = "https://github.com/scientific-python/spin#readme"
+repo = "https://github.com/scientific-python/spin"
+description = "Developer tool wrapper for scientific Python projects"
+
+[detect]
+files = [".spin.toml"]
+dependencies = ["spin"]
+dev_dependencies = ["spin"]
+ecosystems = ["python"]
+[detect.key_exists]
+"pyproject.toml" = ["tool.spin"]
+
+[commands]
+run = "spin"
+alternatives = ["python -m spin"]
+
+[config]
+files = [".spin.toml", "pyproject.toml"]
+
+[taxonomy]
+role = ["build-tool"]
+function = ["automation"]


### PR DESCRIPTION
Refs #61.

brief already parses `Makefile`, `justfile`, `Taskfile.yml` and `package.json` into the Scripts section, but Just, Task, Pixi and Spin had no tool entries so they never appeared under `Build:` or `Environment:` with a command hint.

This adds the four entries:

```
Build:       Just (just --list)  [justfile]
Build:       Task (task --list-all)  [Taskfile.yml]
Environment: Pixi (pixi install)  [pixi.toml]
Build:       Spin (spin)  [pyproject.toml]
```

Pixi goes under `environment` alongside Mise since it's primarily a conda-based environment manager; `pixi task list` and `pixi run` are in its alternatives. Spin is detected via `[tool.spin]` in `pyproject.toml`, a `.spin.toml`, or the dependency.

When a Taskfile or Justfile has a target named `build` the existing script-linking takes over and shows `task build` or `just build` instead of the list command, which is usually what you want.

This doesn't close #61 since the question there is broader; see the reply on that issue for the policy on running list commands.