### PR TITLE
Set goconst to ignore test files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,3 +3,8 @@ version: "2"
 formatters:
   enable:
     - gofmt
+
+linters:
+  settings:
+    goconst:
+      ignore-tests: true

--- a/cmd/brief/main.go
+++ b/cmd/brief/main.go
@@ -324,7 +324,7 @@ func cmdSchema() {
 // Named struct types are emitted as $ref pointers into the $defs map.
 func schemaForType(t reflect.Type, defs map[string]any) map[string]any {
 	// Unwrap pointers.
-	for t.Kind() == reflect.Ptr {
+	for t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 


### PR DESCRIPTION
Path exclusions only filter where goconst issues are reported, not which files contribute to the occurrence count, so a string used once in production code and twice in tests still gets flagged. The `ignore-tests` setting makes goconst skip test files entirely.