### PR TITLE
Add remaining detection-only library definitions

### DIFF
--- a/knowledge/java/dom4j.toml
+++ b/knowledge/java/dom4j.toml
@@ -1,0 +1,34 @@
+[tool]
+name = "dom4j"
+category = "library"
+homepage = "https://dom4j.github.io"
+docs = "https://dom4j.github.io"
+repo = "https://github.com/dom4j/dom4j"
+description = "XML, XPath, and XSLT library for Java"
+
+[detect]
+dependencies = ["org.dom4j:dom4j", "dom4j:dom4j"]
+ecosystems = ["java"]
+
+[taxonomy]
+role = ["library"]
+function = ["parsing"]
+layer = ["backend"]
+
+[[security.sinks]]
+symbol = "SAXReader.read"
+threat = "xxe"
+cwe = "CWE-611"
+note = "Disable external entities when parsing caller-controlled XML"
+
+[[security.sinks]]
+symbol = "DocumentHelper.parseText"
+threat = "xxe"
+cwe = "CWE-611"
+note = "Parses XML strings; ensure the reader is hardened against XXE"
+
+[[security.sinks]]
+symbol = "XSLTResultTarget"
+threat = "xxe"
+cwe = "CWE-611"
+note = "XSLT processing can resolve external resources"

--- a/knowledge/java/jdom.toml
+++ b/knowledge/java/jdom.toml
@@ -1,0 +1,33 @@
+[tool]
+name = "JDOM"
+category = "library"
+homepage = "http://www.jdom.org"
+docs = "http://www.jdom.org/docs/apidocs/"
+repo = "https://github.com/hunterhacker/jdom"
+description = "Java XML document model"
+
+[detect]
+dependencies = ["org.jdom:jdom2", "jdom:jdom"]
+ecosystems = ["java"]
+
+[taxonomy]
+role = ["library"]
+function = ["parsing"]
+layer = ["backend"]
+
+[[security.sinks]]
+symbol = "SAXBuilder.build"
+threat = "xxe"
+cwe = "CWE-611"
+note = "Disable DTDs and external entities for caller-controlled XML"
+
+[[security.sinks]]
+symbol = "DOMBuilder.build"
+threat = "xxe"
+cwe = "CWE-611"
+
+[[security.sinks]]
+symbol = "XSLTransformer"
+threat = "xxe"
+cwe = "CWE-611"
+note = "XSLT processing can resolve external resources"

--- a/knowledge/java/spring-security.toml
+++ b/knowledge/java/spring-security.toml
@@ -1,0 +1,51 @@
+[tool]
+name = "Spring Security"
+category = "library"
+homepage = "https://spring.io/projects/spring-security"
+docs = "https://docs.spring.io/spring-security/reference/"
+repo = "https://github.com/spring-projects/spring-security"
+description = "Authentication and authorization framework for Spring applications"
+
+[detect]
+dependencies = [
+  "org.springframework.security:spring-security-core",
+  "org.springframework.security:spring-security-web",
+  "org.springframework.security:spring-security-config",
+  "org.springframework.security:spring-security-oauth2-resource-server",
+]
+ecosystems = ["java", "kotlin"]
+
+[taxonomy]
+role = ["library"]
+function = ["authentication"]
+layer = ["backend"]
+
+[[security.sinks]]
+symbol = "@Secured"
+threat = "auth_bypass"
+cwe = "CWE-285"
+note = "Method-level authorization; verify role expressions cover all callers"
+
+[[security.sinks]]
+symbol = "@PreAuthorize"
+threat = "auth_bypass"
+cwe = "CWE-285"
+note = "SpEL authorization expression; deny-by-default mistakes bypass checks"
+
+[[security.sinks]]
+symbol = "csrf().disable"
+threat = "csrf"
+cwe = "CWE-352"
+note = "Disables CSRF protection for browser-authenticated routes"
+
+[[security.sinks]]
+symbol = "NoOpPasswordEncoder"
+threat = "weak_crypto"
+cwe = "CWE-327"
+note = "Stores or compares passwords without hashing"
+
+[[security.sinks]]
+symbol = "oauth2ResourceServer"
+threat = "auth_bypass"
+cwe = "CWE-287"
+note = "Verify issuer, audience, and algorithm validation"

--- a/knowledge/java/velocity.toml
+++ b/knowledge/java/velocity.toml
@@ -1,0 +1,39 @@
+[tool]
+name = "Velocity"
+category = "library"
+homepage = "https://velocity.apache.org"
+docs = "https://velocity.apache.org/engine/"
+repo = "https://github.com/apache/velocity-engine"
+description = "Template engine for Java"
+
+[detect]
+dependencies = ["org.apache.velocity:velocity-engine-core", "org.apache.velocity:velocity"]
+ecosystems = ["java"]
+
+[taxonomy]
+role = ["library"]
+function = ["templating"]
+layer = ["backend"]
+
+[[security.sinks]]
+symbol = "Velocity.evaluate"
+threat = "ssti"
+cwe = "CWE-1336"
+note = "Evaluates template strings; dangerous when template text is caller-controlled"
+
+[[security.sinks]]
+symbol = "RuntimeServices.evaluate"
+threat = "ssti"
+cwe = "CWE-1336"
+
+[[security.sinks]]
+symbol = "Template.merge"
+threat = "xss"
+cwe = "CWE-79"
+note = "Velocity does not auto-escape HTML output by default"
+
+[[security.sinks]]
+symbol = "#evaluate"
+threat = "ssti"
+cwe = "CWE-1336"
+note = "Template directive that evaluates generated VTL"

--- a/knowledge/node/busboy.toml
+++ b/knowledge/node/busboy.toml
@@ -1,0 +1,34 @@
+[tool]
+name = "Busboy"
+category = "library"
+homepage = "https://github.com/mscdex/busboy"
+docs = "https://github.com/mscdex/busboy"
+repo = "https://github.com/mscdex/busboy"
+description = "Streaming parser for HTML form data"
+
+[detect]
+dependencies = ["busboy"]
+ecosystems = ["node"]
+
+[taxonomy]
+role = ["library"]
+function = ["file-management", "parsing"]
+layer = ["backend"]
+
+[[security.sinks]]
+symbol = "filename"
+threat = "path_traversal"
+cwe = "CWE-22"
+note = "Client-controlled Content-Disposition filename"
+
+[[security.sinks]]
+symbol = "preservePath"
+threat = "path_traversal"
+cwe = "CWE-22"
+note = "Preserves client-supplied path components when enabled"
+
+[[security.sinks]]
+symbol = "file"
+threat = "dos"
+cwe = "CWE-400"
+note = "Set fileSize, files, and parts limits for untrusted uploads"

--- a/knowledge/node/cross-spawn.toml
+++ b/knowledge/node/cross-spawn.toml
@@ -1,0 +1,33 @@
+[tool]
+name = "cross-spawn"
+category = "library"
+homepage = "https://github.com/moxystudio/node-cross-spawn"
+docs = "https://github.com/moxystudio/node-cross-spawn"
+repo = "https://github.com/moxystudio/node-cross-spawn"
+description = "Cross-platform child_process.spawn wrapper"
+
+[detect]
+dependencies = ["cross-spawn"]
+ecosystems = ["node"]
+
+[taxonomy]
+role = ["library"]
+function = ["process-execution"]
+layer = ["backend"]
+
+[[security.sinks]]
+symbol = "spawn"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "Array argv form is safer; shell option or caller-controlled command is dangerous"
+
+[[security.sinks]]
+symbol = "spawn.sync"
+threat = "command_injection"
+cwe = "CWE-78"
+
+[[security.sinks]]
+symbol = "shell"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "options.shell passes through a command shell"

--- a/knowledge/php/laravel-sanctum.toml
+++ b/knowledge/php/laravel-sanctum.toml
@@ -1,0 +1,34 @@
+[tool]
+name = "Laravel Sanctum"
+category = "library"
+homepage = "https://laravel.com/docs/sanctum"
+docs = "https://laravel.com/docs/sanctum"
+repo = "https://github.com/laravel/sanctum"
+description = "API token and SPA authentication for Laravel"
+
+[detect]
+dependencies = ["laravel/sanctum"]
+ecosystems = ["php"]
+
+[taxonomy]
+role = ["library"]
+function = ["authentication"]
+layer = ["backend"]
+
+[[security.sinks]]
+symbol = "tokenCan"
+threat = "auth_bypass"
+cwe = "CWE-285"
+note = "Returns true for first-party SPA requests; pair with policy checks"
+
+[[security.sinks]]
+symbol = "createToken"
+threat = "auth_bypass"
+cwe = "CWE-285"
+note = "Over-broad abilities or missing expiry expand token access"
+
+[[security.sinks]]
+symbol = "EnsureFrontendRequestsAreStateful"
+threat = "csrf"
+cwe = "CWE-352"
+note = "SPA cookie auth depends on correct stateful domain and CSRF configuration"

--- a/knowledge/python/celery.toml
+++ b/knowledge/python/celery.toml
@@ -1,0 +1,39 @@
+[tool]
+name = "Celery"
+category = "library"
+homepage = "https://docs.celeryq.dev"
+docs = "https://docs.celeryq.dev"
+repo = "https://github.com/celery/celery"
+description = "Distributed task queue for Python"
+
+[detect]
+dependencies = ["celery"]
+ecosystems = ["python"]
+
+[taxonomy]
+role = ["library"]
+function = ["messaging", "serialization"]
+layer = ["backend"]
+
+[[security.sinks]]
+symbol = "task_serializer = \"pickle\""
+threat = "deserialization"
+cwe = "CWE-502"
+note = "Pickle task messages execute code during deserialization"
+
+[[security.sinks]]
+symbol = "accept_content = [\"pickle\"]"
+threat = "deserialization"
+cwe = "CWE-502"
+note = "Accepting pickle messages from untrusted brokers is dangerous"
+
+[[security.sinks]]
+symbol = "result_serializer = \"pickle\""
+threat = "deserialization"
+cwe = "CWE-502"
+
+[[security.sinks]]
+symbol = "send_task"
+threat = "auth_bypass"
+cwe = "CWE-306"
+note = "Unauthenticated broker access can enqueue arbitrary tasks"

--- a/knowledge/python/fabric.toml
+++ b/knowledge/python/fabric.toml
@@ -1,0 +1,34 @@
+[tool]
+name = "Fabric"
+category = "library"
+homepage = "https://www.fabfile.org"
+docs = "https://docs.fabfile.org"
+repo = "https://github.com/fabric/fabric"
+description = "Python SSH command execution library"
+
+[detect]
+dependencies = ["fabric"]
+ecosystems = ["python"]
+
+[taxonomy]
+role = ["library"]
+function = ["process-execution"]
+layer = ["backend"]
+
+[[security.sinks]]
+symbol = "Connection.run"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "Runs a remote shell command"
+
+[[security.sinks]]
+symbol = "Connection.sudo"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "Runs a remote command with elevated privileges"
+
+[[security.sinks]]
+symbol = "Connection.local"
+threat = "command_injection"
+cwe = "CWE-78"
+note = "Runs a local shell command through Invoke"

--- a/knowledge/rust/tera.toml
+++ b/knowledge/rust/tera.toml
@@ -1,0 +1,34 @@
+[tool]
+name = "Tera"
+category = "library"
+homepage = "https://keats.github.io/tera/"
+docs = "https://keats.github.io/tera/docs/"
+repo = "https://github.com/Keats/tera"
+description = "Template engine for Rust"
+
+[detect]
+dependencies = ["tera"]
+ecosystems = ["rust"]
+
+[taxonomy]
+role = ["library"]
+function = ["templating"]
+layer = ["backend"]
+
+[[security.sinks]]
+symbol = "safe"
+threat = "xss"
+cwe = "CWE-79"
+note = "Filter that marks output as safe and bypasses escaping"
+
+[[security.sinks]]
+symbol = "Tera::one_off"
+threat = "ssti"
+cwe = "CWE-1336"
+note = "Renders a template string; dangerous when template text is caller-controlled"
+
+[[security.sinks]]
+symbol = "render_str"
+threat = "ssti"
+cwe = "CWE-1336"
+note = "Renders caller-provided template strings"


### PR DESCRIPTION
Closes #35.

## Summary

Adds the remaining detection-only library definitions requested in #35:

- Java: Spring Security, Velocity, dom4j, JDOM
- PHP: Laravel Sanctum
- Node.js: cross-spawn, Busboy
- Python: Fabric, Celery
- Rust: Tera

Each definition includes dependency-based detection, ecosystem tags, taxonomy metadata, and relevant security sinks where applicable.

## Validation

```bash
go test ./...
go run ./cmd/brief list tools | rg -C 1 '"name": "(Busboy|Celery|Fabric|JDOM|Laravel Sanctum|Spring Security|Tera|Velocity|cross-spawn|dom4j)"'
```