### PR TITLE
Bump github.com/git-pkgs/outline to 0.1.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/git-pkgs/forge v0.5.1
 	github.com/git-pkgs/licensecheck v0.4.1
 	github.com/git-pkgs/manifests v0.5.0
-	github.com/git-pkgs/outline v0.1.4
+	github.com/git-pkgs/outline v0.1.5
 	github.com/git-pkgs/purl v0.1.12
 	github.com/git-pkgs/registries v0.6.1
 	github.com/git-pkgs/spdx v0.1.4
@@ -161,7 +161,7 @@ require (
 	github.com/nishanths/predeclared v0.2.2 // indirect
 	github.com/nunnatsa/ginkgolinter v0.23.0 // indirect
 	github.com/oapi-codegen/runtime v1.4.1 // indirect
-	github.com/odvcencio/gotreesitter v0.20.2 // indirect
+	github.com/odvcencio/gotreesitter v0.20.6 // indirect
 	github.com/package-url/packageurl-go v0.1.6 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,8 @@ github.com/git-pkgs/licensecheck v0.4.1 h1:b5ilmpIpgeeewBFjdhJ4W7jvwPIFsYQ7ujZma
 github.com/git-pkgs/licensecheck v0.4.1/go.mod h1:cfFO7yHHPeuXsoODHBWyevajH2yWcbfkIFELyG3ZpU0=
 github.com/git-pkgs/manifests v0.5.0 h1:1w+mDqU8IfJ9ojCJaZZv3Zij5cyQMuMT+6pOIND/KAE=
 github.com/git-pkgs/manifests v0.5.0/go.mod h1:s0Bky+73EXicySAIQ1XEnLF5sWShZYrsKOt7dM3htaA=
-github.com/git-pkgs/outline v0.1.4 h1:9cTT59bSoiY3SDL+3lYzsjXtnHeOCMfyno3u8TJ7cIc=
-github.com/git-pkgs/outline v0.1.4/go.mod h1:e51+mPUk+2e1s+07r0FnwP2MchuIjNskHVs4Uktb58Q=
+github.com/git-pkgs/outline v0.1.5 h1:5JC6zS+DRCc9a/0sBodvyGu53q+LXOTlpueqlO68lk8=
+github.com/git-pkgs/outline v0.1.5/go.mod h1:sMPQQf59eAQXEC2x4gTO3fau8IRE2WjyEeB3Xln3+LA=
 github.com/git-pkgs/packageurl-go v0.3.1 h1:WM3RBABQZLaRBxgKyYughc3cVBE8KyQxbSC6Jt5ak7M=
 github.com/git-pkgs/packageurl-go v0.3.1/go.mod h1:rcIxiG37BlQLB6FZfgdj9Fm7yjhRQd3l+5o7J0QPAk4=
 github.com/git-pkgs/pom v0.1.4 h1:C6st+XSbF75eKuwfdkDZZtYHoTcaWRIEQYar5VtszUo=
@@ -489,8 +489,8 @@ github.com/oapi-codegen/nullable v1.1.0 h1:eAh8JVc5430VtYVnq00Hrbpag9PFRGWLjxR1/
 github.com/oapi-codegen/nullable v1.1.0/go.mod h1:KUZ3vUzkmEKY90ksAmit2+5juDIhIZhfDl+0PwOQlFY=
 github.com/oapi-codegen/runtime v1.4.1 h1:9nwLoI+KrWxzbBcp0jO/R8uXqbik/HUyCvPeU68Y/qo=
 github.com/oapi-codegen/runtime v1.4.1/go.mod h1:GwV7hC2hviaMzj+ITfHVRESK5J2W/GefVwIND/bMGvU=
-github.com/odvcencio/gotreesitter v0.20.2 h1:oWxGgy0WzLJKeiZB8EFzXDDlHYG/hqiZmWrW+81uwy4=
-github.com/odvcencio/gotreesitter v0.20.2/go.mod h1:hBVkghd0paaYAVwd2087vfwdeU984bQbMo9LvpE0moo=
+github.com/odvcencio/gotreesitter v0.20.6 h1:tGq0vJwlpprxf5/2cfSVSo58dtvAj6/3Y39CjXtohbY=
+github.com/odvcencio/gotreesitter v0.20.6/go.mod h1:hBVkghd0paaYAVwd2087vfwdeU984bQbMo9LvpE0moo=
 github.com/onsi/ginkgo/v2 v2.28.1 h1:S4hj+HbZp40fNKuLUQOYLDgZLwNUVn19N3Atb98NCyI=
 github.com/onsi/ginkgo/v2 v2.28.1/go.mod h1:CLtbVInNckU3/+gC8LzkGUb9oF+e8W8TdUsxPwvdOgE=
 github.com/onsi/gomega v1.39.1 h1:1IJLAad4zjPn2PsnhH70V4DKRFlrCzGBNrNaru+Vf28=


### PR DESCRIPTION
Bumps `github.com/git-pkgs/outline` 0.1.4 -> 0.1.5, which pulls `gotreesitter` 0.20.2 -> 0.20.6.

This fixes the per-language normaliser recursion that crashed `brief outline` on large Go and multi-language repos. Verified against the projects that previously crashed: `gin`, `echo`, `fiber`, `ent`, `buf`, `helm`, `ansible`, `Newtonsoft.Json`, `thrift`, `terraform`, `podman`, `pulumi`, `golang/go`, `kubernetes`, and `cloud.google.com/go` all now produce outline output cleanly.

One repo, `dotnet/fsharp`, still crashes, but on a separate gotreesitter bug (a slice-bounds panic in the F# external scanner) unrelated to this fix.