### PR TITLE
ci: Make Windows Defender step best-effort on Windows runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,12 @@ jobs:
       - name: Disable Windows Defender real-time monitoring
         if: runner.os == 'Windows'
         shell: powershell
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
+        run: |
+          try {
+            Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction Stop
+          } catch {
+            Write-Warning "Could not disable Windows Defender real-time monitoring: $_"
+          }
 
       - name: Build
         run: go build -v ./...


### PR DESCRIPTION
## Description

This PR updates `.github/workflows/ci.yml` to make the step that disables Windows Defender real-time monitoring a "best-effort" operation.

Previously, if `Set-MpPreference` failed (due to runner permission restrictions, environment updates, or transient issues), it would cause the entire CI pipeline to fail on Windows. By wrapping this command in a PowerShell `try/catch` block, we ensure that any failures simply emit a warning rather than hard-crashing and interrupting the subsequent build and test steps.

**Note:** This change was originally included as part of #96, but was extracted into this standalone PR as requested here https://github.com/git-pkgs/brief/pull/96#pullrequestreview-4588011135.