### PR TITLE
detect: recognise DISCLOSURE as a security resource

### DIFF
--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -141,6 +141,7 @@ func TestResourceGroups(t *testing.T) {
 	touch(".github/CODEOWNERS")
 	touch(".github/FUNDING.yml")
 	touch("docs/SECURITY.md")
+	touch("DISCLOSURE")
 	touch("CITATION.cff")
 
 	engine := New(loadKB(t), dir)
@@ -173,6 +174,9 @@ func TestResourceGroups(t *testing.T) {
 	}
 	if res.Security["policy"] != "docs/SECURITY.md" {
 		t.Errorf("security.policy = %q", res.Security["policy"])
+	}
+	if res.Security["disclosure"] != "DISCLOSURE" {
+		t.Errorf("security.disclosure = %q", res.Security["disclosure"])
 	}
 	if res.Metadata["funding"] != ".github/FUNDING.yml" {
 		t.Errorf("metadata.funding = %q", res.Metadata["funding"])

--- a/knowledge/_shared/_resources.toml
+++ b/knowledge/_shared/_resources.toml
@@ -151,6 +151,13 @@ field = "audit"
 group = "security"
 patterns = ["audit", "audit.md", "audit.txt", "audit.rst"]
 
+[[resources]]
+[resources.resource]
+name = "Disclosure"
+field = "disclosure"
+group = "security"
+patterns = ["disclosure", "disclosure.md", "disclosure.txt"]
+
 # Metadata (machine-readable)
 
 [[resources]]


### PR DESCRIPTION
npm's dual-use content policy requires a `DISCLOSURE` file at the package root describing security-relevant capabilities, sitting alongside `LICENSE`. Report it under `resources.security.disclosure` alongside `policy`, `threat_model` and `audit`.

Announcement: https://github.blog/changelog/2026-07-28-npm-publish-time-malware-scanning-and-dual-use-metadata/
Policy: https://docs.npmjs.com/policies/dual-use