### PR TITLE
Update outline to v0.1.8

### DIFF
--- a/cmd/brief/outline.go
+++ b/cmd/brief/outline.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"runtime/debug"
 	"strings"
@@ -54,12 +55,12 @@ func cmdOutline(args []string) {
 		opts.Ignore = strings.Split(*ignore, ",")
 	}
 
-	code := runOutline(src.Dir, opts, *xmlFlag)
+	code := runOutline(src.Dir, opts, *xmlFlag, os.Stdout)
 	src.Cleanup()
 	os.Exit(code)
 }
 
-func runOutline(dir string, opts outline.Options, xmlOut bool) int {
+func runOutline(dir string, opts outline.Options, xmlOut bool, output io.Writer) int {
 	r, err := outline.Pack(dir, opts)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
@@ -67,9 +68,9 @@ func runOutline(dir string, opts outline.Options, xmlOut bool) int {
 	}
 
 	if xmlOut {
-		err = r.XML(os.Stdout)
+		err = r.XML(output)
 	} else {
-		err = r.Markdown(os.Stdout)
+		err = r.Markdown(output)
 	}
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "error writing output: %v\n", err)

--- a/cmd/brief/outline_test.go
+++ b/cmd/brief/outline_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/git-pkgs/outline"
+)
+
+var benchmarkOutlineResult *outline.Result
+
+func TestRunOutlineSkipsDetectedBinaryContent(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "main.go", "package main\n\nfunc main() {}\n")
+	writeFile(t, dir, "document.pdf", "%PDF-1.7\nbody\n")
+
+	var output bytes.Buffer
+	if code := runOutline(dir, outline.Options{}, false, &output); code != 0 {
+		t.Fatalf("runOutline() = %d, want 0", code)
+	}
+
+	got := output.String()
+	if !strings.Contains(got, "### document.pdf\n\n_(skipped: binary,") {
+		t.Errorf("output does not mark PDF as binary:\n%s", got)
+	}
+	if strings.Contains(got, "%PDF-1.7") {
+		t.Errorf("output includes PDF content:\n%s", got)
+	}
+	if !strings.Contains(got, "package main") {
+		t.Errorf("output omits text content:\n%s", got)
+	}
+}
+
+func BenchmarkOutlinePack(b *testing.B) {
+	dir := b.TempDir()
+	for i := range 100 {
+		name := "source-" + strconv.Itoa(i) + ".go"
+		content := []byte("package source\n\nfunc Value() int { return 1 }\n")
+		if err := os.WriteFile(filepath.Join(dir, name), content, 0o644); err != nil {
+			b.Fatal(err)
+		}
+	}
+	for i := range 10 {
+		name := "document-" + strconv.Itoa(i) + ".pdf"
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("%PDF-1.7\nbody\n"), 0o644); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	opts := outline.Options{Concurrency: 1}
+	b.ResetTimer()
+	for b.Loop() {
+		result, err := outline.Pack(dir, opts)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchmarkOutlineResult = result
+	}
+}

--- a/cmd/brief/outline_test.go
+++ b/cmd/brief/outline_test.go
@@ -19,13 +19,17 @@ func TestRunOutlineSkipsDetectedBinaryContent(t *testing.T) {
 	writeFile(t, dir, "document.pdf", "%PDF-1.7\nbody\n")
 
 	var output bytes.Buffer
-	if code := runOutline(dir, outline.Options{}, false, &output); code != 0 {
+	opts := outline.Options{Compress: true}
+	if code := runOutline(dir, opts, false, &output); code != 0 {
 		t.Fatalf("runOutline() = %d, want 0", code)
 	}
 
 	got := output.String()
-	if !strings.Contains(got, "### document.pdf\n\n_(skipped: binary,") {
-		t.Errorf("output does not mark PDF as binary:\n%s", got)
+	if !strings.Contains(got, "document.pdf") {
+		t.Errorf("output omits PDF path:\n%s", got)
+	}
+	if !strings.Contains(got, "skipped: binary") {
+		t.Errorf("output does not mark content as binary:\n%s", got)
 	}
 	if strings.Contains(got, "%PDF-1.7") {
 		t.Errorf("output includes PDF content:\n%s", got)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/git-pkgs/forge v0.7.0
 	github.com/git-pkgs/licensecheck v0.4.1
 	github.com/git-pkgs/manifests v0.6.1
-	github.com/git-pkgs/outline v0.1.7
+	github.com/git-pkgs/outline v0.1.8
 	github.com/git-pkgs/purl v0.1.15
 	github.com/git-pkgs/registries v0.6.4
 	github.com/git-pkgs/spdx v0.1.4
@@ -21,6 +21,7 @@ require (
 	github.com/bazelbuild/buildtools v0.0.0-20260622120422-77b9b380c0a4 // indirect
 	github.com/ecosyste-ms/ecosystems-go v0.4.0 // indirect
 	github.com/git-pkgs/gitignore v1.2.0 // indirect
+	github.com/git-pkgs/magic v0.1.0 // indirect
 	github.com/git-pkgs/packageurl-go v0.3.1 // indirect
 	github.com/git-pkgs/pom v0.1.5 // indirect
 	github.com/git-pkgs/vers v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,10 +20,12 @@ github.com/git-pkgs/gitignore v1.2.0 h1:7vdR8/SvF31dvXqIdC1bKgCvyySefXuN8aY3xJLu
 github.com/git-pkgs/gitignore v1.2.0/go.mod h1:Lr0XwhbvP071rZF/zIIhkY1gEhFDoWHH91lngwLpeUg=
 github.com/git-pkgs/licensecheck v0.4.1 h1:b5ilmpIpgeeewBFjdhJ4W7jvwPIFsYQ7ujZma7sli6k=
 github.com/git-pkgs/licensecheck v0.4.1/go.mod h1:cfFO7yHHPeuXsoODHBWyevajH2yWcbfkIFELyG3ZpU0=
+github.com/git-pkgs/magic v0.1.0 h1:xLrqq7CMXB9g5bJnmJyKw17Rvlh0GFiEmO6e5RFsoeY=
+github.com/git-pkgs/magic v0.1.0/go.mod h1:3ndidt+yvFaI1M0aEkkzkOlFnLPkeVQASIUojazcxCI=
 github.com/git-pkgs/manifests v0.6.1 h1:lkdtkipyFmJHJVUktkQH7TzliJbYFigCS7kczJHQxFA=
 github.com/git-pkgs/manifests v0.6.1/go.mod h1:za7j4NTkJQ/mk8H5m6Na93dMftGsZrHAYaZzGJNUPQs=
-github.com/git-pkgs/outline v0.1.7 h1:rRuFpfuxb1uMf+57IZ1gwgipCVp6BYrj2JcjHJX19M0=
-github.com/git-pkgs/outline v0.1.7/go.mod h1:qqaXC+qpxgH2QlZmHQzJoYEph+DayPNMI3I1m61QJGU=
+github.com/git-pkgs/outline v0.1.8 h1:559sqAEapAkyfe/VUqNeVXok8tMILuFAEpFdvSfB86c=
+github.com/git-pkgs/outline v0.1.8/go.mod h1:FnrnEIwuLgWmeT8vJTKJpPhLr83XtKJMmfmJtcjeYk4=
 github.com/git-pkgs/packageurl-go v0.3.1 h1:WM3RBABQZLaRBxgKyYughc3cVBE8KyQxbSC6Jt5ak7M=
 github.com/git-pkgs/packageurl-go v0.3.1/go.mod h1:rcIxiG37BlQLB6FZfgdj9Fm7yjhRQd3l+5o7J0QPAk4=
 github.com/git-pkgs/pom v0.1.5 h1:TGT8Az2OMxGWsXnSagtUMGzZm7Oax8HrSCteA+mi0qY=


### PR DESCRIPTION
Update `outline` to v0.1.8 so `brief outline` inherits content-based binary classification from `magic`.

Add a command-level fixture for ASCII PDF content that the previous classifier treated as text and a fixed outline benchmark. Interleaved measurements on this repository show startup at +1.05%, a normal scan at +0.16%, and outline at -0.47%. The linked binary grows by 33,776 bytes, while benchmark allocations fall from 1,929 to 1,919.