### PR TITLE
Match NOTICE files with a wildcard like license does

### DIFF
--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -258,7 +258,7 @@ func TestResourceGroups(t *testing.T) {
 	touch("README.md")
 	touch("CHANGELOG.md")
 	touch("AGENTS.md")
-	touch("NOTICE")
+	touch("NOTICES.md")
 	touch("CONTRIBUTING.md")
 	touch(".github/CODE_OF_CONDUCT.md")
 	touch(".github/CODEOWNERS")
@@ -283,7 +283,7 @@ func TestResourceGroups(t *testing.T) {
 	if res.Agents["agents"] != "AGENTS.md" {
 		t.Errorf("agents.agents = %q", res.Agents["agents"])
 	}
-	if res.Legal["notice"] != "NOTICE" {
+	if res.Legal["notice"] != "NOTICES.md" {
 		t.Errorf("legal.notice = %q", res.Legal["notice"])
 	}
 	if res.Community["contributing"] != "CONTRIBUTING.md" {

--- a/knowledge/_shared/_resources.toml
+++ b/knowledge/_shared/_resources.toml
@@ -43,7 +43,7 @@ patterns = ["copyright", "copyright.md", "copyright.txt"]
 name = "Notice"
 field = "notice"
 group = "legal"
-patterns = ["notice*"]
+patterns = ["notice", "notice.md", "notice.txt", "notices", "notices.md", "notices.txt"]
 dirs = ["docs", ".github", ".gitlab"]
 
 [[resources]]

--- a/knowledge/_shared/_resources.toml
+++ b/knowledge/_shared/_resources.toml
@@ -43,7 +43,7 @@ patterns = ["copyright", "copyright.md", "copyright.txt"]
 name = "Notice"
 field = "notice"
 group = "legal"
-patterns = ["notice", "notice.md", "notice.txt"]
+patterns = ["notice*"]
 dirs = ["docs", ".github", ".gitlab"]
 
 [[resources]]


### PR DESCRIPTION
The explicit `["notice", "notice.md", "notice.txt"]` list missed `NOTICES` (plural) and extensions other than `.md`/`.txt`. `notice*` covers `NOTICE`, `NOTICES`, `NOTICE.rst`, `NOTICE-THIRD-PARTY` and so on, matching how the `license` entry already uses `license*`.

Aligns with how `git-pkgs/licenses` recognises notice files (`isLegalFile` accepts both `notice` and `notices` prefixes).