### PR TITLE
Use Go 1.26.6 toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/git-pkgs/brief
 
 go 1.26
 
+toolchain go1.26.6
+
 require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/git-pkgs/enrichment v0.6.5


### PR DESCRIPTION
Keep the minimum Go version at 1.26 while selecting Go 1.26.6 as the preferred toolchain for development, CI, and releases.